### PR TITLE
Hey Noah,I think i've found a bug in rivescript-python :)

### DIFF
--- a/rivescript.py
+++ b/rivescript.py
@@ -1263,7 +1263,7 @@ there was no match, this will return None."""
                 if isAtomic:
                     # Only look for exact matches, no sense running atomic triggers
                     # through the regexp engine.
-                    if msg == trig:
+                    if msg == regexp:
                         isMatch = True
                 else:
                     # Non-atomic triggers always need the regexp.


### PR DESCRIPTION
when i'm using

![2013-05-12 4 39 03 pm](https://f.cloud.github.com/assets/1311594/492709/84fe7d30-badf-11e2-9db4-f21b6662a339.png)

and when i inputed messages, the bot replied like this:
![2013-05-12 4 29 15 pm](https://f.cloud.github.com/assets/1311594/492710/977ce62c-badf-11e2-86a7-b51452b7bced.png)

by checking the source code, i found the bug that the program tried to match 'your age' with 'your age{weight=10}'.
after fixing this, i got correct answers from the bot:

![2013-05-12 4 40 51 pm](https://f.cloud.github.com/assets/1311594/492711/b13ac5ac-badf-11e2-857a-0754ef5cba69.png)

Best wishes
-Dinever
