### PR TITLE
Fixed missing "re" import

### DIFF
--- a/rivescript/interactive.py
+++ b/rivescript/interactive.py
@@ -11,6 +11,7 @@ The preferred method is the former."""
 
 __docformat__ = 'plaintext'
 
+import re
 import sys
 import getopt
 import json


### PR DESCRIPTION
You're missing a `re` import, which breaks the interactive JSON mode.
