### PR TITLE
Python 2/3 unicode compatibility fix

### DIFF
--- a/rivescript/rivescript.py
+++ b/rivescript/rivescript.py
@@ -23,6 +23,7 @@
 # SOFTWARE.
 
 from __future__ import unicode_literals
+from six import text_type
 import sys
 import os
 import re
@@ -207,7 +208,7 @@ This may be called as either a class method or a method of a RiveScript object."
         `code` can either be a string containing RiveScript code or an array
         of lines of RiveScript code."""
         self._say("Streaming code.")
-        if type(code) in [str, unicode]:
+        if type(code) in [str, text_type]:
             code = code.split("\n")
         self._parse("stream()", code)
 
@@ -838,7 +839,7 @@ Returns a syntax error string on error; None otherwise."""
             for var in sorted(deparsed["begin"][kind].keys()):
                 # Array types need to be separated by either spaces or pipes.
                 data = deparsed["begin"][kind][var]
-                if type(data) not in [str, unicode]:
+                if type(data) not in [str, text_type]:
                     needs_pipes = False
                     for test in data:
                         if " " in test:
@@ -2108,7 +2109,7 @@ the value is unset at the end of the `reply()` method)."""
                 if "=" in data:
                     # Setting a bot/env variable.
                     parts = data.split("=")
-                    self._say("Set " + tag + " variable " + unicode(parts[0]) + "=" + unicode(parts[1]))
+                    self._say("Set " + tag + " variable " + text_type(parts[0]) + "=" + text_type(parts[1]))
                     target[parts[0]] = parts[1]
                 else:
                     # Getting a bot/env variable.
@@ -2116,7 +2117,7 @@ the value is unset at the end of the `reply()` method)."""
             elif tag == "set":
                 # <set> user vars.
                 parts = data.split("=")
-                self._say("Set uservar " + unicode(parts[0]) + "=" + unicode(parts[1]))
+                self._say("Set uservar " + text_type(parts[0]) + "=" + text_type(parts[1]))
                 self._users[user][parts[0]] = parts[1]
             elif tag in ["add", "sub", "mult", "div"]:
                 # Math operator tags.

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         'Intended Audience :: Developers',
         'Topic :: Scientific/Engineering :: Artificial Intelligence',
     ],
-    install_requires = [ 'setuptools' ],
+    install_requires = [ 'setuptools', 'six' ],
 )
 
 # vim:expandtab


### PR DESCRIPTION
This pull request resolves a compatibility issue with Python 3. As all strings are unicode by default in Python 3, "unicode" itself no longer exists, though it is still used regardless of Python version in a few areas of RiveScript.

When setting a variable, for example,
```
python3 example3.py 
This is a bare minimal example for how to write your own RiveScript bot!

For a more full-fledged example, try running: `python rivescript brain`
This will run the built-in Interactive Mode of the RiveScript library. It has
some more advanced features like supporting JSON for communication with the
bot. See `python rivescript --help` for more info.

example3.py is just a simple script that loads the RiveScript documents from
the 'brain/' folder, and lets you chat with the bot.

Type /quit when you're done to exit this example.

You> Hello!
Bot> Hi. What seems to be your problem?
You> My name is Makoto
Traceback (most recent call last):
  File "example3.py", line 28, in <module>
    reply = rs.reply("localuser", msg)
  File "/home/makoto/Documents/Projects/Python3/rs/rivescript-python/rivescript/rivescript.py", line 1531, in reply
    reply = self._getreply(user, msg)
  File "/home/makoto/Documents/Projects/Python3/rs/rivescript-python/rivescript/rivescript.py", line 1853, in _getreply
    reply = self._process_tags(user, msg, reply, stars, thatstars, step)
  File "/home/makoto/Documents/Projects/Python3/rs/rivescript-python/rivescript/rivescript.py", line 2119, in _process_tags
    self._say("Set uservar " + unicode(parts[0]) + "=" + unicode(parts[1]))
NameError: name 'unicode' is not defined
```

This pull requests adds the popular **six** library as a setup requirement and utilizes its text_type method in place of unicode for compatibility with both Python 2 and 3.
```
python3 example3.py 
This is a bare minimal example for how to write your own RiveScript bot!

For a more full-fledged example, try running: `python rivescript brain`
This will run the built-in Interactive Mode of the RiveScript library. It has
some more advanced features like supporting JSON for communication with the
bot. See `python rivescript --help` for more info.

example3.py is just a simple script that loads the RiveScript documents from
the 'brain/' folder, and lets you chat with the bot.

Type /quit when you're done to exit this example.

You> Hello!
Bot> Hi. What seems to be your problem?
You> My name is Makoto
Bot> Nice to meet you, Makoto.
You> 
```