### PR TITLE
RiveScript exceptions

### DIFF
--- a/rivescript/__init__.py
+++ b/rivescript/__init__.py
@@ -41,4 +41,5 @@ __docformat__  = 'plaintext'
 __all__      = ['rivescript']
 __version__  = '1.07'
 
-from .rivescript import RiveScript
+from .rivescript import RiveScript, RiveScriptError, NoMatchError, NoReplyError,\
+    ObjectError, DeepRecursionError, NoDefaultRandomTopicError, RepliesNotSortedError

--- a/rivescript/python.py
+++ b/rivescript/python.py
@@ -67,7 +67,7 @@ handler on your RiveScript object:
 
         try:
             exec(source)
-            #self._objects[name] = RSOBJ
+            # self._objects[name] = RSOBJ
         except Exception as e:
             print("Failed to load code from object", name)
             print("The error given was: ", e)
@@ -75,7 +75,7 @@ handler on your RiveScript object:
     def call(self, rs, name, user, fields):
         """Invoke a previously loaded object."""
         # Call the dynamic method.
-        if not name in self._objects:
+        if name not in self._objects:
             return '[ERR: Object Not Found]'
         func = self._objects[name]
         reply = ''
@@ -84,6 +84,9 @@ handler on your RiveScript object:
             if reply is None:
                 reply = ''
         except Exception as e:
-            print("Error executing Python object:", e)
-            reply = '[ERR: Error when executing Python object]'
+            raise PythonObjectError("Error executing Python object: " + str(e))
         return str(reply)
+
+
+class PythonObjectError(Exception):
+    pass

--- a/rivescript/rivescript.py
+++ b/rivescript/rivescript.py
@@ -1870,9 +1870,9 @@ the value is unset at the end of the `reply()` method)."""
 
         # Safety checking.
         if 'lists' not in self._sorted:
-            raise Exception("You forgot to call sort_replies()!")
+            raise RepliesNotSortedError("You must call sort_replies() once you are done loading RiveScript documents")
         if kind not in self._sorted["lists"]:
-            raise Exception("You forgot to call sort_replies()!")
+            raise RepliesNotSortedError("You must call sort_replies() once you are done loading RiveScript documents")
 
         # Get the substitution map.
         subs = None

--- a/rivescript/rivescript.py
+++ b/rivescript/rivescript.py
@@ -80,7 +80,7 @@ RS_ERR_REPLY = "[ERR: No reply found]"
 RS_ERR_DEEP_RECURSION = "[ERR: Deep recursion detected]"
 RS_ERR_OBJECT = "[ERR: Error when executing Python object]"
 RS_ERR_OBJECT_HANDLER = "[ERR: No Object Handler]"
-RS_ERR_OBJECT_MISSING = "[ERR: Error when executing Python object]"
+RS_ERR_OBJECT_MISSING = "[ERR: Object Not Found]"
 
 
 class RiveScript(object):
@@ -2216,7 +2216,7 @@ the value is unset at the end of the `reply()` method)."""
                     except python.PythonObjectError as e:
                         self._warn(str(e))
                         if not ignore_object_errors:
-                            raise ObjectError
+                            raise ObjectError(str(e))
                         output = RS_ERR_OBJECT
                 else:
                     if not ignore_object_errors:


### PR DESCRIPTION
Currently, when RiveScript encounters an error, such as a reply not being matched or a Python object throwing an exception, RiveScript simply returns an error message as a string response.

For some (simpler) use cases, this is probably fine. However, more complex applications may wish to catch and handle such events instead of simply returning the error message to the client.

For simple no reply / no match errors, you could perform a match against the RS_ERR constants, or utilize a simple regex like this,
```python

```python
self.error_pattern = re.compile("(^ERR:)|(\[ERR:.*\])")

# Make sure we didn't get an error in our response
if self.error_pattern.match(reply):
    self.log.debug('Received an ERROR response: ' + reply)
    reply = None
```
However, this in itself is really not ideal. Furthermore, it becomes even more complex if you want to be able to match Object errors and handle those independently.

This pull request implements various exceptions which RiveScript can raise instead of returning error responses as strings. To enable this functionality, when calling the reply() method, set the added third "errors_as_replies" argument to False. This is the result,
```
makoto@ArchLinux:~/Documents/Projects/Python3/rivescript-python$ python3 except_test.py 
Failed to load code from object badhandler
The error given was:  invalid syntax (<string>, line 4)
This is a bare minimal example for how to write your own RiveScript bot!

For a more full-fledged example, try running: `python rivescript brain`
This will run the built-in Interactive Mode of the RiveScript library. It has
some more advanced features like supporting JSON for communication with the
bot. See `python rivescript --help` for more info.

example3.py is just a simple script that loads the RiveScript documents from
the 'brain/' folder, and lets you chat with the bot.

Type /quit when you're done to exit this example.

You> Hello!
Bot> How do you do. Please state your problem.
You> No reply example
Traceback (most recent call last):
  File "except_test.py", line 28, in <module>
    reply = rs.reply("localuser", msg, errors_as_replies=False)
  File "/home/makoto/Documents/Projects/Python3/rivescript-python/rivescript/rivescript.py", line 1536, in reply
    reply = self._getreply(user, msg, ignore_object_errors=errors_as_replies)
  File "/home/makoto/Documents/Projects/Python3/rivescript-python/rivescript/rivescript.py", line 1845, in _getreply
    raise NoMatchError
rivescript.rivescript.NoMatchError: [ERR: No reply matched]
makoto@ArchLinux:~/Documents/Projects/Python3/rivescript-python$ python3 except_test.py 
Failed to load code from object badhandler
The error given was:  invalid syntax (<string>, line 4)
This is a bare minimal example for how to write your own RiveScript bot!

For a more full-fledged example, try running: `python rivescript brain`
This will run the built-in Interactive Mode of the RiveScript library. It has
some more advanced features like supporting JSON for communication with the
bot. See `python rivescript --help` for more info.

example3.py is just a simple script that loads the RiveScript documents from
the 'brain/' folder, and lets you chat with the bot.

Type /quit when you're done to exit this example.

You> throw an exception
[RS] Error executing Python object: division by zero
Traceback (most recent call last):
  File "/home/makoto/Documents/Projects/Python3/rivescript-python/rivescript/python.py", line 83, in call
    reply = func(rs, fields)
  File "<string>", line 2, in RSOBJ
ZeroDivisionError: division by zero

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/makoto/Documents/Projects/Python3/rivescript-python/rivescript/rivescript.py", line 2215, in _process_tags
    output = self._handlers[lang].call(self, obj, user, args)
  File "/home/makoto/Documents/Projects/Python3/rivescript-python/rivescript/python.py", line 87, in call
    raise PythonObjectError("Error executing Python object: " + str(e))
rivescript.python.PythonObjectError: Error executing Python object: division by zero

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "except_test.py", line 28, in <module>
    reply = rs.reply("localuser", msg, errors_as_replies=False)
  File "/home/makoto/Documents/Projects/Python3/rivescript-python/rivescript/rivescript.py", line 1536, in reply
    reply = self._getreply(user, msg, ignore_object_errors=errors_as_replies)
  File "/home/makoto/Documents/Projects/Python3/rivescript-python/rivescript/rivescript.py", line 1868, in _getreply
    reply = self._process_tags(user, msg, reply, stars, thatstars, step, ignore_object_errors)
  File "/home/makoto/Documents/Projects/Python3/rivescript-python/rivescript/rivescript.py", line 2219, in _process_tags
    raise ObjectError(str(e))
rivescript.rivescript.ObjectError: Error executing Python object: division by zero
makoto@ArchLinux:~/Documents/Projects/Python3/rivescript-python$ python3 except_test.py 
Failed to load code from object badhandler
The error given was:  invalid syntax (<string>, line 4)
This is a bare minimal example for how to write your own RiveScript bot!

For a more full-fledged example, try running: `python rivescript brain`
This will run the built-in Interactive Mode of the RiveScript library. It has
some more advanced features like supporting JSON for communication with the
bot. See `python rivescript --help` for more info.

example3.py is just a simple script that loads the RiveScript documents from
the 'brain/' folder, and lets you chat with the bot.

Type /quit when you're done to exit this example.

You> give me an invalid object
Traceback (most recent call last):
  File "except_test.py", line 28, in <module>
    reply = rs.reply("localuser", msg, errors_as_replies=False)
  File "/home/makoto/Documents/Projects/Python3/rivescript-python/rivescript/rivescript.py", line 1536, in reply
    reply = self._getreply(user, msg, ignore_object_errors=errors_as_replies)
  File "/home/makoto/Documents/Projects/Python3/rivescript-python/rivescript/rivescript.py", line 1868, in _getreply
    reply = self._process_tags(user, msg, reply, stars, thatstars, step, ignore_object_errors)
  File "/home/makoto/Documents/Projects/Python3/rivescript-python/rivescript/rivescript.py", line 2227, in _process_tags
    raise ObjectError(RS_ERR_OBJECT_MISSING)
rivescript.rivescript.ObjectError: [ERR: Object Not Found]
makoto@ArchLinux:~/Documents/Projects/Python3/rivescript-python$ 
```

Now you can implement a simple try catch statement to handle these exceptions in your application instead of trying to use rudimentary regular expression to parse and catch any returned errors,
```python
#!/usr/bin/python3

# Python 3 example with exception handling

from rivescript import RiveScript, RiveScriptError, ObjectError

rs = RiveScript()
rs.load_directory("./brain")
rs.sort_replies()

print("""This is a bare minimal example for how to write your own RiveScript bot!

For a more full-fledged example, try running: `python rivescript brain`
This will run the built-in Interactive Mode of the RiveScript library. It has
some more advanced features like supporting JSON for communication with the
bot. See `python rivescript --help` for more info.

example3.py is just a simple script that loads the RiveScript documents from
the 'brain/' folder, and lets you chat with the bot.

Type /quit when you're done to exit this example.
""")

while True:
    msg = input("You> ")
    if msg == '/quit':
        quit()
    try:
        reply = rs.reply("localuser", msg, errors_as_replies=False)
        print("Bot>", reply)
    except ObjectError as e:
        print(e.error_message)
    except RiveScriptError:
        print('No reply could be matched!')
```
"RiveScriptError" being the general catch-all exception class for all non-critical errors here.

The result,
```
You> Hello
Bot> Hi. What seems to be your problem?
You> No match
No reply could be matched!
You> throw an exception
[RS] Error executing Python object: division by zero
Error executing Python object: division by zero
```

Of course, this is just a very simple example. In a real word scenario, you could probably want to perform your own logging on Python object errors and just refuse to send a response when a reply is not matched.

(To perform the above test, I simply commented out the wildcard match in eliza.rive and added the below to python.rive)
```
> object exception python
	0 / 0
< object

+ give me an invalid object
- <call>null</call>

+ throw an exception
- <call>exception</call>
```