### PR TITLE
Fix UnicodeDecodeError in Python 2 with Object Macros

### DIFF
--- a/rivescript/python.py
+++ b/rivescript/python.py
@@ -24,6 +24,7 @@
 
 # Python3 compat
 from __future__ import print_function, unicode_literals
+from six import text_type
 
 __docformat__ = 'plaintext'
 
@@ -98,7 +99,7 @@ class PyRiveObjects(object):
                 reply = ''
         except Exception as e:
             raise PythonObjectError("Error executing Python object: " + str(e))
-        return str(reply)
+        return text_type(reply)
 
 
 class PythonObjectError(Exception):

--- a/rivescript/rivescript.py
+++ b/rivescript/rivescript.py
@@ -2293,7 +2293,7 @@ class RiveScript(object):
             # non-matching.
             pipes = '|'.join(new)
             pipes = re.sub(self._quotemeta(r'(.+?)'), '(?:.+?)', pipes)
-            pipes = re.sub(self._quotemeta(r'(\\d+?)'), '(?:\d+?)', pipes)
+            pipes = re.sub(self._quotemeta(r'(\d+?)'), '(?:\d+?)', pipes)
             pipes = re.sub(self._quotemeta(r'([A-Za-z]+?)'), '(?:[A-Za-z]+?)', pipes)
 
             regexp = re.sub(r'\s*\[' + self._quotemeta(match) + '\]\s*',

--- a/rivescript/rivescript.py
+++ b/rivescript/rivescript.py
@@ -2292,9 +2292,9 @@ class RiveScript(object):
             # If this optional had a star or anything in it, make it
             # non-matching.
             pipes = '|'.join(new)
-            pipes = re.sub(re.escape('(.+?)'), '(?:.+?)', pipes)
-            pipes = re.sub(re.escape('(\d+?)'), '(?:\d+?)', pipes)
-            pipes = re.sub(re.escape('([A-Za-z]+?)'), '(?:[A-Za-z]+?)', pipes)
+            pipes = re.sub(re.escape(r'(.+?)'), '(?:.+?)', pipes)
+            pipes = re.sub(re.escape(r'(\\d+?)'), '(?:\d+?)', pipes)
+            pipes = re.sub(re.escape(r'([A-Za-z]+?)'), '(?:[A-Za-z]+?)', pipes)
 
             regexp = re.sub(r'\s*\[' + re.escape(match) + '\]\s*',
                 '(?:' + pipes + r'|(?:\\s|\\b))', regexp)

--- a/rivescript/rivescript.py
+++ b/rivescript/rivescript.py
@@ -2208,7 +2208,7 @@ class RiveScript(object):
         :param str pattern: The substitution pattern.
         """
         if pattern not in self._regexc[kind]:
-            qm = re.escape(pattern)
+            qm = self._quotemeta(pattern)
             self._regexc[kind][pattern] = {
                 "qm": qm,
                 "sub1": re.compile(r'^' + qm + r'$'),
@@ -2292,11 +2292,11 @@ class RiveScript(object):
             # If this optional had a star or anything in it, make it
             # non-matching.
             pipes = '|'.join(new)
-            pipes = re.sub(re.escape(r'(.+?)'), '(?:.+?)', pipes)
-            pipes = re.sub(re.escape(r'(\\d+?)'), '(?:\d+?)', pipes)
-            pipes = re.sub(re.escape(r'([A-Za-z]+?)'), '(?:[A-Za-z]+?)', pipes)
+            pipes = re.sub(self._quotemeta(r'(.+?)'), '(?:.+?)', pipes)
+            pipes = re.sub(self._quotemeta(r'(\\d+?)'), '(?:\d+?)', pipes)
+            pipes = re.sub(self._quotemeta(r'([A-Za-z]+?)'), '(?:[A-Za-z]+?)', pipes)
 
-            regexp = re.sub(r'\s*\[' + re.escape(match) + '\]\s*',
+            regexp = re.sub(r'\s*\[' + self._quotemeta(match) + '\]\s*',
                 '(?:' + pipes + r'|(?:\\s|\\b))', regexp)
 
         # _ wildcards can't match numbers!
@@ -2308,7 +2308,7 @@ class RiveScript(object):
             rep = ''
             if array in self._arrays:
                 rep = r'(?:' + '|'.join(self._expand_array(array)) + ')'
-            regexp = re.sub(r'\@' + re.escape(array) + r'\b', rep, regexp)
+            regexp = re.sub(r'\@' + self._quotemeta(array) + r'\b', rep, regexp)
 
         # Filter in bot variables.
         bvars = re.findall(RE.bot_tag, regexp)
@@ -2769,6 +2769,20 @@ class RiveScript(object):
     ############################################################################
     # Miscellaneous Private Methods                                            #
     ############################################################################
+
+    def _quotemeta(self, s):
+        """Escape a string to make it safe for a regular expression.
+
+        This is used instead of ``self._quotemeta()`` because Python 3.6 obsoleted
+        the ``\d`` escape sequence for some reason for that function.
+
+        :param str s: The string to make regexp-safe.
+        :return str: The string with all regexp metacharacters escaped.
+        """
+        unsafe = list(r'\.+?[^]$(){}=!<>|:')
+        for char in unsafe:
+            s = s.replace(char, "\\{}".format(char))
+        return s
 
     def _is_atomic(self, trigger):
         """Determine if a trigger is atomic or not.


### PR DESCRIPTION
This fixes a bug for Python 2 where a Python object macro was unable to return a Unicode string, due to the Python macro handler casting all return values as `str()` type, which in Python 2, assumes ASCII, and it would raise a `UnicodeDecodeError`.

Instead the return value is casted to `six.text_type` which will be `unicode` in Python 2 and `str` in Python 3.

The following RiveScript example code demonstrates the original problem and that this change fixes it:

```
> object wiki python
	import re
	import requests

	res = requests.get("http://bulbapedia.bulbagarden.net/wiki/Umbreon_(Pok%C3%A9mon)")
	m = re.search(r': <b>(.+?)</b> <i>Blacky</i>', res.text)

	if m:
		name = m.group(1)
		return name
	return "No match"
< object

+ test
- Result: <call>wiki</call>
```

Expected result:

```
You> test
Bot> Result: ブラッキー
```