### PR TITLE
Restructure the source code like the JS/Go versions

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,14 @@
 Revision history for the Python package RiveScript.
 
+1.13.0  TBD
+  - Restructure the code to keep it on par with the JavaScript and Go versions:
+    - `rivescript.parser` now contains all the parsing code:
+      `parse()` and `check_syntax()` are moved here.
+  - Refactor the RiveScript interactive mode (`rivescript.interactive`) to use
+    argparse instead of getopt and add a pretty ASCII logo.
+  - Add `shell.py` as a possibly easier-to-access (and certainly
+    easier-to-discover) shortcut to running RiveScript's interactive mode.
+
 1.12.3  Jul 8 2016
   - Fix the Python object macro handler to use `six.text_type` on the return
     value, allowing Python 2 objects to return Unicode strings.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+all: build
+
+build:
+	python setup.py build
+
+install:
+	python setup.py install
+
+test:
+	pip install -r requirements.txt
+	nosetests
+
+clean:
+	rm -rf build dist rivescript.egg-info
+	find . -name '*.pyc' -delete
+
+.PHONY: build install test clean

--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ interactive chat session:
 
     python rivescript ./eg/brain
 
+In case running RiveScript as a script is inconvenient (for example, when it's
+installed as a system module) you can use the `shell.py` script as an alias:
+
+    python shell.py eg/brain
+
 When used as a library, the synopsis is as follows:
 
 ```python

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,6 +37,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.todo',
     'sphinx.ext.viewcode',
+    'sphinx.ext.napoleon',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/rivescript.rst
+++ b/docs/rivescript.rst
@@ -12,6 +12,14 @@ rivescript.rivescript module
     :undoc-members:
     :show-inheritance:
 
+rivescript.brain module
+-----------------------
+
+.. automodule:: rivescript.brain
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 rivescript.exceptions module
 ----------------------------
 
@@ -20,11 +28,58 @@ rivescript.exceptions module
     :undoc-members:
     :show-inheritance:
 
+rivescript.inheritance module
+-----------------------------
+
+.. automodule:: rivescript.inheritance
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+rivescript.interactive module
+-----------------------------
+
+.. automodule:: rivescript.interactive
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+rivescript.parser module
+------------------------
+
+.. automodule:: rivescript.parser
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 rivescript.python module
 ------------------------
 
 .. automodule:: rivescript.python
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+rivescript.regexp module
+------------------------
+
+.. automodule:: rivescript.regexp
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+rivescript.sorting module
+-------------------------
+
+.. automodule:: rivescript.sorting
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+rivescript.utils module
+-----------------------
+
+.. automodule:: rivescript.utils
     :members:
     :undoc-members:
     :show-inheritance:

--- a/mkdocs.sh
+++ b/mkdocs.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-rm -rf docs/*
-epydoc -v -o docs --name RiveScript --url https://github.com/aichaos/rivescript-python rivescript.rivescript rivescript.python

--- a/rivescript/__init__.py
+++ b/rivescript/__init__.py
@@ -1,28 +1,9 @@
-#!/usr/bin/env python
-
-# pyRiveScript - A RiveScript interpreter written in Python.
-
-# The MIT License (MIT)
+# RiveScript-Python
 #
-# Copyright (c) 2016 Noah Petherbridge
+# This code is released under the MIT License.
+# See the "LICENSE" file for more information.
 #
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# https://www.rivescript.com/
 
 # Python 3 compat
 from __future__ import print_function, unicode_literals
@@ -39,7 +20,10 @@ __status__     = 'Production'
 __docformat__  = 'plaintext'
 
 __all__      = ['rivescript']
-__version__  = '1.12.3'
+__version__  = '1.12.4'
 
-from .rivescript import RiveScript, RiveScriptError, NoMatchError, NoReplyError,\
-    ObjectError, DeepRecursionError, NoDefaultRandomTopicError, RepliesNotSortedError
+from .rivescript import RiveScript
+from .exceptions import (
+    RiveScriptError, NoMatchError, NoReplyError, ObjectError,
+    DeepRecursionError, NoDefaultRandomTopicError, RepliesNotSortedError
+)

--- a/rivescript/__main__.py
+++ b/rivescript/__main__.py
@@ -1,26 +1,9 @@
-#!/usr/bin/env python
-
-# The MIT License (MIT)
+# RiveScript-Python
 #
-# Copyright (c) 2016 Noah Petherbridge
+# This code is released under the MIT License.
+# See the "LICENSE" file for more information.
 #
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# https://www.rivescript.com/
 
 from __future__ import absolute_import, unicode_literals
 

--- a/rivescript/brain.py
+++ b/rivescript/brain.py
@@ -1,0 +1,813 @@
+# RiveScript-Python
+#
+# This code is released under the MIT License.
+# See the "LICENSE" file for more information.
+#
+# https://www.rivescript.com/
+
+from .regexp import RE
+from .exceptions import (
+    RiveScriptError, RepliesNotSortedError, NoDefaultRandomTopicError,
+    DeepRecursionError, NoMatchError, NoReplyError, ObjectError,
+    RS_ERR_OBJECT, RS_ERR_OBJECT_HANDLER, RS_ERR_OBJECT_MISSING
+)
+from . import python
+from . import inheritance as inherit_utils
+from . import utils
+import random
+import re
+from six import text_type
+import sys
+
+class Brain(object):
+    """The Brain class controls the actual reply fetching phase for RiveScript.
+
+    Parameters:
+        master (RiveScript): A reference to the parent RiveScript instance.
+        strict (bool): Whether strict mode is enabled.
+        utf8 (bool): Whether UTF-8 mode is enabled.
+    """
+
+    def __init__(self, master, strict=True, utf8=False):
+        self.master = master
+        self.strict = strict
+        self.utf8   = utf8
+
+        # Private variables only relevant to the reply-answering part of RiveScript.
+        self._current_user = None
+
+    # Proxy functions.
+    def say(self, *args, **kwargs):
+        self.master._say(*args, **kwargs)
+    def warn(self, *args, **kwargs):
+        self.master._warn(*args, **kwargs)
+
+    def reply(self, user, msg, errors_as_replies=True):
+        self.say("Get reply to [" + user + "] " + msg)
+
+        # Store the current user in case an object macro needs it.
+        self._current_user = user
+
+        # Format their message.
+        msg = self.format_message(msg)
+
+        reply = ''
+
+        # If the BEGIN block exists, consult it first.
+        if "__begin__" in self.master._topics:
+            try:
+                begin = self._getreply(user, 'request', context='begin', ignore_object_errors=errors_as_replies)
+            except RiveScriptError as e:
+                if not errors_as_replies:
+                    raise
+                return e.error_message
+
+            # Okay to continue?
+            if '{ok}' in begin:
+                try:
+                    reply = self._getreply(user, msg, ignore_object_errors=errors_as_replies)
+                except RiveScriptError as e:
+                    if not errors_as_replies:
+                        raise
+                    reply = e.error_message
+                begin = begin.replace('{ok}', reply)
+
+            reply = begin
+
+            # Run more tag substitutions.
+            reply = self.process_tags(user, msg, reply, ignore_object_errors=errors_as_replies)
+        else:
+            # Just continue then.
+            try:
+                reply = self._getreply(user, msg, ignore_object_errors=errors_as_replies)
+            except RiveScriptError as e:
+                if not errors_as_replies:
+                    raise
+                reply = e.error_message
+
+        # Save their reply history.
+        oldInput = self.master._users[user]['__history__']['input'][:8]
+        self.master._users[user]['__history__']['input'] = [msg]
+        self.master._users[user]['__history__']['input'].extend(oldInput)
+        oldReply = self.master._users[user]['__history__']['reply'][:8]
+        self.master._users[user]['__history__']['reply'] = [reply]
+        self.master._users[user]['__history__']['reply'].extend(oldReply)
+
+        # Unset the current user.
+        self._current_user = None
+
+        return reply
+
+    def format_message(self, msg, botreply=False):
+        """Format a user's message for safe processing.
+
+        This runs substitutions on the message and strips out any remaining
+        symbols (depending on UTF-8 mode).
+
+        :param str msg: The user's message.
+        :param bool botreply: Whether this formatting is being done for the
+            bot's last reply (e.g. in a ``%Previous`` command).
+
+        :return str: The formatted message.
+        """
+
+        # Make sure the string is Unicode for Python 2.
+        if sys.version_info[0] < 3 and isinstance(msg, str):
+            msg = msg.decode()
+
+        # Lowercase it.
+        msg = msg.lower()
+
+        # Run substitutions on it.
+        msg = self.substitute(msg, "sub")
+
+        # In UTF-8 mode, only strip metacharacters and HTML brackets
+        # (to protect from obvious XSS attacks).
+        if self.utf8:
+            msg = re.sub(RE.utf8_meta, '', msg)
+            msg = re.sub(self.master.unicode_punctuation, '', msg)
+
+            # For the bot's reply, also strip common punctuation.
+            if botreply:
+                msg = re.sub(RE.utf8_punct, '', msg)
+        else:
+            # For everything else, strip all non-alphanumerics.
+            msg = utils.strip_nasties(msg)
+
+        return msg
+
+    def _getreply(self, user, msg, context='normal', step=0, ignore_object_errors=True):
+        """The internal reply getter function.
+
+        DO NOT CALL THIS YOURSELF.
+
+        :param str user: The user ID as passed to ``reply()``.
+        :param str msg: The formatted user message.
+        :param str context: The reply context, one of ``begin`` or ``normal``.
+        :param int step: The recursion depth counter.
+        :param bool ignore_object_errors: Whether to ignore errors from within
+            Python object macros and not raise an ``ObjectError`` exception.
+
+        :return str: The reply output.
+        """
+        # Needed to sort replies?
+        if 'topics' not in self.master._sorted:
+            raise RepliesNotSortedError("You must call sort_replies() once you are done loading RiveScript documents")
+
+        # Initialize the user's profile?
+        if user not in self.master._users:
+            self.master._users[user] = {'topic': 'random'}
+
+        # Collect data on the user.
+        topic     = self.master._users[user]['topic']
+        stars     = []
+        thatstars = []  # For %Previous's.
+        reply     = ''
+
+        # Avoid letting them fall into a missing topic.
+        if topic not in self.master._topics:
+            self.warn("User " + user + " was in an empty topic named '" + topic + "'")
+            topic = self.master._users[user]['topic'] = 'random'
+
+        # Avoid deep recursion.
+        if step > self.master._depth:
+            raise DeepRecursionError
+
+        # Are we in the BEGIN statement?
+        if context == 'begin':
+            topic = '__begin__'
+
+        # Initialize this user's history.
+        if '__history__' not in self.master._users[user]:
+            self.master._users[user]['__history__'] = {
+                'input': [
+                    'undefined', 'undefined', 'undefined', 'undefined',
+                    'undefined', 'undefined', 'undefined', 'undefined',
+                    'undefined'
+                ],
+                'reply': [
+                    'undefined', 'undefined', 'undefined', 'undefined',
+                    'undefined', 'undefined', 'undefined', 'undefined',
+                    'undefined'
+                ]
+            }
+
+        # More topic sanity checking.
+        if topic not in self.master._topics:
+            # This was handled before, which would mean topic=random and
+            # it doesn't exist. Serious issue!
+            raise NoDefaultRandomTopicError("no default topic 'random' was found")
+
+        # Create a pointer for the matched data when we find it.
+        matched        = None
+        matchedTrigger = None
+        foundMatch     = False
+
+        # See if there were any %Previous's in this topic, or any topic related
+        # to it. This should only be done the first time -- not during a
+        # recursive redirection. This is because in a redirection, "lastreply"
+        # is still gonna be the same as it was the first time, causing an
+        # infinite loop!
+        if step == 0:
+            allTopics = [topic]
+            if topic in self.master._includes or topic in self.master._lineage:
+                # Get all the topics!
+                allTopics = inherit_utils.get_topic_tree(self.master, topic)
+
+            # Scan them all!
+            for top in allTopics:
+                self.say("Checking topic " + top + " for any %Previous's.")
+                if top in self.master._sorted["thats"]:
+                    self.say("There is a %Previous in this topic!")
+
+                    # Do we have history yet?
+                    lastReply = self.master._users[user]["__history__"]["reply"][0]
+
+                    # Format the bot's last reply the same way as the human's.
+                    lastReply = self.format_message(lastReply, botreply=True)
+                    self.say("lastReply: " + lastReply)
+
+                    # See if it's a match.
+                    for trig in self.master._sorted["thats"][top]:
+                        pattern = trig[0]
+                        botside = self.reply_regexp(user, pattern)
+                        self.say("Try to match lastReply (" + lastReply + ") to " + pattern)
+
+                        # Match??
+                        match = re.match(botside, lastReply)
+                        if match:
+                            # Huzzah! See if OUR message is right too.
+                            self.say("Bot side matched!")
+                            thatstars = match.groups()
+
+                            # Compare the triggers to the user's message.
+                            user_side = trig[1]
+                            subtrig = self.reply_regexp(user, user_side["trigger"])
+                            self.say("Now try to match " + msg + " to " + user_side["trigger"])
+
+                            match = re.match(subtrig, msg)
+                            if match:
+                                self.say("Found a match!")
+                                matched = trig[1]
+                                matchedTrigger = subtrig
+                                foundMatch = True
+
+                                # Get the stars!
+                                stars = match.groups()
+                                break
+
+                        # Break if we found a match.
+                        if foundMatch:
+                            break
+                # Break if we found a match.
+                if foundMatch:
+                    break
+
+        # Search their topic for a match to their trigger.
+        if not foundMatch:
+            for trig in self.master._sorted["topics"][topic]:
+                pattern = trig[0]
+
+                # Process the triggers.
+                regexp = self.reply_regexp(user, pattern)
+                self.say("Try to match %r against %r (%r)" % (msg, pattern, regexp.pattern))
+
+                # Python's regular expression engine is slow. Try a verbatim
+                # match if this is an atomic trigger.
+                isAtomic = utils.is_atomic(pattern)
+                isMatch = False
+                if isAtomic:
+                    # Only look for exact matches, no sense running atomic triggers
+                    # through the regexp engine.
+                    if msg == pattern:
+                        isMatch = True
+                else:
+                    # Non-atomic triggers always need the regexp.
+                    match = re.match(regexp, msg)
+                    if match:
+                        # The regexp matched!
+                        isMatch = True
+
+                        # Collect the stars.
+                        stars = match.groups()
+
+                if isMatch:
+                    self.say("Found a match!")
+
+                    matched = trig[1]
+                    foundMatch = True
+                    matchedTrigger = pattern
+                    break
+
+        # Store what trigger they matched on. If their matched trigger is None,
+        # this will be too, which is great.
+        self.master._users[user]["__lastmatch__"] = matchedTrigger
+
+        if matched:
+            for nil in [1]:
+                # See if there are any hard redirects.
+                if matched["redirect"]:
+                    self.say("Redirecting us to " + matched["redirect"])
+                    redirect = self.process_tags(user, msg, matched["redirect"], stars, thatstars, step,
+                                                  ignore_object_errors)
+                    self.say("Pretend user said: " + redirect)
+                    reply = self._getreply(user, redirect, step=(step + 1), ignore_object_errors=ignore_object_errors)
+                    break
+
+                # Check the conditionals.
+                for con in matched["condition"]:
+                    halves = re.split(RE.cond_split, con)
+                    if halves and len(halves) == 2:
+                        condition = re.match(RE.cond_parse, halves[0])
+                        if condition:
+                            left     = condition.group(1)
+                            eq       = condition.group(2)
+                            right    = condition.group(3)
+                            potreply = halves[1]
+                            self.say("Left: " + left + "; eq: " + eq + "; right: " + right + " => " + potreply)
+
+                            # Process tags all around.
+                            left  = self.process_tags(user, msg, left, stars, thatstars, step, ignore_object_errors)
+                            right = self.process_tags(user, msg, right, stars, thatstars, step, ignore_object_errors)
+
+                            # Defaults?
+                            if len(left) == 0:
+                                left = 'undefined'
+                            if len(right) == 0:
+                                right = 'undefined'
+
+                            self.say("Check if " + left + " " + eq + " " + right)
+
+                            # Validate it.
+                            passed = False
+                            if eq == 'eq' or eq == '==':
+                                if left == right:
+                                    passed = True
+                            elif eq == 'ne' or eq == '!=' or eq == '<>':
+                                if left != right:
+                                    passed = True
+                            else:
+                                # Gasp, dealing with numbers here...
+                                try:
+                                    left, right = int(left), int(right)
+                                    if eq == '<':
+                                        if left < right:
+                                            passed = True
+                                    elif eq == '<=':
+                                        if left <= right:
+                                            passed = True
+                                    elif eq == '>':
+                                        if left > right:
+                                            passed = True
+                                    elif eq == '>=':
+                                        if left >= right:
+                                            passed = True
+                                except:
+                                    self.warn("Failed to evaluate numeric condition!")
+
+                            # How truthful?
+                            if passed:
+                                reply = potreply
+                                break
+
+                # Have our reply yet?
+                if len(reply) > 0:
+                    break
+
+                # Process weights in the replies.
+                bucket = []
+                for text in matched["reply"]:
+                    weight = 1
+                    match  = re.match(RE.weight, text)
+                    if match:
+                        weight = int(match.group(1))
+                        if weight <= 0:
+                            self.warn("Can't have a weight <= 0!")
+                            weight = 1
+                    for i in range(0, weight):
+                        bucket.append(text)
+
+                # Get a random reply.
+                reply = random.choice(bucket)
+                break
+
+        # Still no reply?
+        if not foundMatch:
+            raise NoMatchError
+        elif len(reply) == 0:
+            raise NoReplyError
+
+        self.say("Reply: " + reply)
+
+        # Process tags for the BEGIN block.
+        if context == "begin":
+            # BEGIN blocks can only set topics and uservars. The rest happen
+            # later!
+            reTopic = re.findall(RE.topic_tag, reply)
+            for match in reTopic:
+                self.say("Setting user's topic to " + match)
+                self.master._users[user]["topic"] = match
+                reply = reply.replace('{{topic={match}}}'.format(match=match), '')
+
+            reSet = re.findall(RE.set_tag, reply)
+            for match in reSet:
+                self.say("Set uservar " + str(match[0]) + "=" + str(match[1]))
+                self.master._users[user][match[0]] = match[1]
+                reply = reply.replace('<set {key}={value}>'.format(key=match[0], value=match[1]), '')
+        else:
+            # Process more tags if not in BEGIN.
+            reply = self.process_tags(user, msg, reply, stars, thatstars, step, ignore_object_errors)
+
+        return reply
+
+    def reply_regexp(self, user, regexp):
+        """Prepares a trigger for the regular expression engine.
+
+        :param str user: The user ID invoking a reply.
+        :param str regexp: The original trigger text to be turned into a regexp.
+
+        :return regexp: The final regexp object."""
+
+        if regexp in self.master._regexc["trigger"]:
+            # Already compiled this one!
+            return self.master._regexc["trigger"][regexp]
+
+        # If the trigger is simply '*' then the * there needs to become (.*?)
+        # to match the blank string too.
+        regexp = re.sub(RE.zero_star, r'<zerowidthstar>', regexp)
+
+        # Simple replacements.
+        regexp = regexp.replace('*', '(.+?)')   # Convert * into (.+?)
+        regexp = regexp.replace('#', '(\d+?)')  # Convert # into (\d+?)
+        regexp = regexp.replace('_', '(\w+?)')  # Convert _ into (\w+?)
+        regexp = re.sub(r'\{weight=\d+\}', '', regexp)  # Remove {weight} tags
+        regexp = regexp.replace('<zerowidthstar>', r'(.*?)')
+
+        # Optionals.
+        optionals = re.findall(RE.optionals, regexp)
+        for match in optionals:
+            parts = match.split("|")
+            new = []
+            for p in parts:
+                p = r'(?:\\s|\\b)+{}(?:\\s|\\b)+'.format(p)
+                new.append(p)
+
+            # If this optional had a star or anything in it, make it
+            # non-matching.
+            pipes = '|'.join(new)
+            pipes = pipes.replace(r'(.+?)', r'(?:.+?)')
+            pipes = pipes.replace(r'(\d+?)', r'(?:\d+?)')
+            pipes = pipes.replace(r'([A-Za-z]+?)', r'(?:[A-Za-z]+?)')
+
+            regexp = re.sub(r'\s*\[' + re.escape(match) + '\]\s*',
+                '(?:' + pipes + r'|(?:\\s|\\b))', regexp)
+
+        # _ wildcards can't match numbers!
+        regexp = re.sub(RE.literal_w, r'[A-Za-z]', regexp)
+
+        # Filter in arrays.
+        arrays = re.findall(RE.array, regexp)
+        for array in arrays:
+            rep = ''
+            if array in self.master._array:
+                rep = r'(?:' + '|'.join(self.expand_array(array)) + ')'
+            regexp = re.sub(r'\@' + re.escape(array) + r'\b', rep, regexp)
+
+        # Filter in bot variables.
+        bvars = re.findall(RE.bot_tag, regexp)
+        for var in bvars:
+            rep = ''
+            if var in self.master._var:
+                rep = utils.strip_nasties(self.master._var[var])
+            regexp = regexp.replace('<bot {var}>'.format(var=var), rep)
+
+        # Filter in user variables.
+        uvars = re.findall(RE.get_tag, regexp)
+        for var in uvars:
+            rep = ''
+            if var in self.master._users[user]:
+                rep = utils.strip_nasties(self.master._users[user][var])
+            regexp = regexp.replace('<get {var}>'.format(var=var), rep)
+
+        # Filter in <input> and <reply> tags. This is a slow process, so only
+        # do it if we have to!
+        if '<input' in regexp or '<reply' in regexp:
+            for type in ['input', 'reply']:
+                tags = re.findall(r'<' + type + r'([0-9])>', regexp)
+                for index in tags:
+                    rep = self.format_message(self.master._users[user]['__history__'][type][int(index) - 1])
+                    regexp = regexp.replace('<{type}{index}>'.format(type=type, index=index), rep)
+                regexp = regexp.replace('<{type}>'.format(type=type),
+                                        self.format_message(self.master._users[user]['__history__'][type][0]))
+                # TODO: the Perl version doesn't do just <input>/<reply> in trigs!
+
+        return re.compile(r'^' + regexp + r'$')
+
+    def do_expand_array(self, array_name, depth=0):
+        """Do recurrent array expansion, returning a set of keywords.
+
+        Exception is thrown when there are cyclical dependencies between
+        arrays or if the ``@array`` name references an undefined array.
+
+        :param str array_name: The name of the array to expand.
+        :param int depth: The recursion depth counter.
+
+        :return set: The final set of array entries.
+        """
+        if depth > self.master._depth:
+            raise Exception("deep recursion detected")
+        if not array_name in self.master._array:
+            raise Exception("array '%s' not defined" % (array_name))
+        ret = list(self.master._array[array_name])
+        for array in self.master._array[array_name]:
+            if array.startswith('@'):
+                ret.remove(array)
+                expanded = self.do_expand_array(array[1:], depth+1)
+                ret.extend(expanded)
+
+        return set(ret)
+
+    def expand_array(self, array_name):
+        """Expand variables and return a set of keywords.
+
+        :param str array_name: The name of the array to expand.
+
+        :return list: The final array contents.
+
+        Warning is issued when exceptions occur."""
+        ret = self.master._array[array_name] if array_name in self.master._array else []
+        try:
+            ret = self.do_expand_array(array_name)
+        except Exception as e:
+            self.warn("Error expanding array '%s': %s" % (array_name, str(e)))
+        return ret
+
+    def process_tags(self, user, msg, reply, st=[], bst=[], depth=0, ignore_object_errors=True):
+        """Post process tags in a message.
+
+        :param str user: The user ID.
+        :param str msg: The user's formatted message.
+        :param str reply: The raw RiveScript reply for the message.
+        :param []str st: The array of ``<star>`` matches from the trigger.
+        :param []str bst: The array of ``<botstar>`` matches from a
+            ``%Previous`` command.
+        :param int depth: The recursion depth counter.
+        :param bool ignore_object_errors: Whether to ignore errors in Python
+            object macros instead of raising an ``ObjectError`` exception.
+
+        :return str: The final reply after tags have been processed.
+        """
+        stars = ['']
+        stars.extend(st)
+        botstars = ['']
+        botstars.extend(bst)
+        if len(stars) == 1:
+            stars.append("undefined")
+        if len(botstars) == 1:
+            botstars.append("undefined")
+
+        # Tag shortcuts.
+        reply = reply.replace('<person>', '{person}<star>{/person}')
+        reply = reply.replace('<@>', '{@<star>}')
+        reply = reply.replace('<formal>', '{formal}<star>{/formal}')
+        reply = reply.replace('<sentence>', '{sentence}<star>{/sentence}')
+        reply = reply.replace('<uppercase>', '{uppercase}<star>{/uppercase}')
+        reply = reply.replace('<lowercase>', '{lowercase}<star>{/lowercase}')
+
+        # Weight and <star> tags.
+        reply = re.sub(RE.weight, '', reply)  # Leftover {weight}s
+        if len(stars) > 0:
+            reply = reply.replace('<star>', stars[1])
+            reStars = re.findall(RE.star_tags, reply)
+            for match in reStars:
+                if int(match) < len(stars):
+                    reply = reply.replace('<star{match}>'.format(match=match), stars[int(match)])
+        if len(botstars) > 0:
+            reply = reply.replace('<botstar>', botstars[1])
+            reStars = re.findall(RE.botstars, reply)
+            for match in reStars:
+                if int(match) < len(botstars):
+                    reply = reply.replace('<botstar{match}>'.format(match=match), botstars[int(match)])
+
+        # <input> and <reply>
+        reply = reply.replace('<input>', self.master._users[user]['__history__']['input'][0])
+        reply = reply.replace('<reply>', self.master._users[user]['__history__']['reply'][0])
+        reInput = re.findall(RE.input_tags, reply)
+        for match in reInput:
+            reply = reply.replace('<input{match}>'.format(match=match),
+                                  self.master._users[user]['__history__']['input'][int(match) - 1])
+        reReply = re.findall(RE.reply_tags, reply)
+        for match in reReply:
+            reply = reply.replace('<reply{match}>'.format(match=match),
+                                  self.master._users[user]['__history__']['reply'][int(match) - 1])
+
+        # <id> and escape codes.
+        reply = reply.replace('<id>', user)
+        reply = reply.replace('\\s', ' ')
+        reply = reply.replace('\\n', "\n")
+        reply = reply.replace('\\#', '#')
+
+        # Random bits.
+        reRandom = re.findall(RE.random_tags, reply)
+        for match in reRandom:
+            output = ''
+            if '|' in match:
+                output = random.choice(match.split('|'))
+            else:
+                output = random.choice(match.split(' '))
+            reply = reply.replace('{{random}}{match}{{/random}}'.format(match=match), output)
+
+        # Person Substitutions and String Formatting.
+        for item in ['person', 'formal', 'sentence', 'uppercase',  'lowercase']:
+            matcher = re.findall(r'\{' + item + r'\}(.+?)\{/' + item + r'\}', reply)
+            for match in matcher:
+                output = None
+                if item == 'person':
+                    # Person substitutions.
+                    output = self.substitute(match, "person")
+                else:
+                    output = utils.string_format(match, item)
+                reply = reply.replace('{{{item}}}{match}{{/{item}}}'.format(item=item, match=match), output)
+
+        # Handle all variable-related tags with an iterative regex approach,
+        # to allow for nesting of tags in arbitrary ways (think <set a=<get b>>)
+        # Dummy out the <call> tags first, because we don't handle them right
+        # here.
+        reply = reply.replace("<call>", "{__call__}")
+        reply = reply.replace("</call>", "{/__call__}")
+        while True:
+            # This regex will match a <tag> which contains no other tag inside
+            # it, i.e. in the case of <set a=<get b>> it will match <get b> but
+            # not the <set> tag, on the first pass. The second pass will get the
+            # <set> tag, and so on.
+            match = re.search(RE.tag_search, reply)
+            if not match: break  # No remaining tags!
+
+            match = match.group(1)
+            parts  = match.split(" ", 1)
+            tag    = parts[0].lower()
+            data   = parts[1] if len(parts) > 1 else ""
+            insert = ""  # Result of the tag evaluation
+
+            # Handle the tags.
+            if tag == "bot" or tag == "env":
+                # <bot> and <env> tags are similar.
+                target = self.master._var if tag == "bot" else self.master._global
+                if "=" in data:
+                    # Setting a bot/env variable.
+                    parts = data.split("=")
+                    self.say("Set " + tag + " variable " + text_type(parts[0]) + "=" + text_type(parts[1]))
+                    target[parts[0]] = parts[1]
+                else:
+                    # Getting a bot/env variable.
+                    insert = target.get(data, "undefined")
+            elif tag == "set":
+                # <set> user vars.
+                parts = data.split("=")
+                self.say("Set uservar " + text_type(parts[0]) + "=" + text_type(parts[1]))
+                self.master._users[user][parts[0]] = parts[1]
+            elif tag in ["add", "sub", "mult", "div"]:
+                # Math operator tags.
+                parts = data.split("=")
+                var   = parts[0]
+                value = parts[1]
+
+                # Sanity check the value.
+                try:
+                    value = int(value)
+                    if var not in self.master._users[user]:
+                        # Initialize it.
+                        self.master._users[user][var] = 0
+                except:
+                    insert = "[ERR: Math can't '{}' non-numeric value '{}']".format(tag, value)
+
+                # Attempt the operation.
+                try:
+                    orig = int(self.master._users[user][var])
+                    new  = 0
+                    if tag == "add":
+                        new = orig + value
+                    elif tag == "sub":
+                        new = orig - value
+                    elif tag == "mult":
+                        new = orig * value
+                    elif tag == "div":
+                        new = orig / value
+                    self.master._users[user][var] = new
+                except:
+                    insert = "[ERR: Math couldn't '{}' to value '{}']".format(tag, self.master._users[user][var])
+            elif tag == "get":
+                insert = self.master._users[user].get(data, "undefined")
+            else:
+                # Unrecognized tag.
+                insert = "\x00{}\x01".format(match)
+
+            reply = reply.replace("<{}>".format(match), insert)
+
+        # Restore unrecognized tags.
+        reply = reply.replace("\x00", "<").replace("\x01", ">")
+
+        # Streaming code. DEPRECATED!
+        if '{!' in reply:
+            self._warn("Use of the {!...} tag is deprecated and not supported here.")
+
+        # Topic setter.
+        reTopic = re.findall(RE.topic_tag, reply)
+        for match in reTopic:
+            self.say("Setting user's topic to " + match)
+            self.master._users[user]["topic"] = match
+            reply = reply.replace('{{topic={match}}}'.format(match=match), '')
+
+        # Inline redirecter.
+        reRedir = re.findall(RE.redir_tag, reply)
+        for match in reRedir:
+            self.say("Redirect to " + match)
+            at = match.strip()
+            subreply = self._getreply(user, at, step=(depth + 1))
+            reply = reply.replace('{{@{match}}}'.format(match=match), subreply)
+
+        # Object caller.
+        reply = reply.replace("{__call__}", "<call>")
+        reply = reply.replace("{/__call__}", "</call>")
+        reCall = re.findall(r'<call>(.+?)</call>', reply)
+        for match in reCall:
+            parts  = re.split(RE.ws, match)
+            output = ''
+            obj    = parts[0]
+            args   = []
+            if len(parts) > 1:
+                args = parts[1:]
+
+            # Do we know this object?
+            if obj in self.master._objlangs:
+                # We do, but do we have a handler for that language?
+                lang = self.master._objlangs[obj]
+                if lang in self.master._handlers:
+                    # We do.
+                    try:
+                        output = self.master._handlers[lang].call(self.master, obj, user, args)
+                    except python.PythonObjectError as e:
+                        self.warn(str(e))
+                        if not ignore_object_errors:
+                            raise ObjectError(str(e))
+                        output = RS_ERR_OBJECT
+                else:
+                    if not ignore_object_errors:
+                        raise ObjectError(RS_ERR_OBJECT_HANDLER)
+                    output = RS_ERR_OBJECT_HANDLER
+            else:
+                if not ignore_object_errors:
+                    raise ObjectError(RS_ERR_OBJECT_MISSING)
+                output = RS_ERR_OBJECT_MISSING
+
+            reply = reply.replace('<call>{match}</call>'.format(match=match), output)
+
+        return reply
+
+    def substitute(self, msg, kind):
+        """Run a kind of substitution on a message.
+
+        :param str msg: The message to run substitutions against.
+        :param str kind: The kind of substitution to run,
+            one of ``subs`` or ``person``.
+        """
+
+        # Safety checking.
+        if 'lists' not in self.master._sorted:
+            raise RepliesNotSortedError("You must call sort_replies() once you are done loading RiveScript documents")
+        if kind not in self.master._sorted["lists"]:
+            raise RepliesNotSortedError("You must call sort_replies() once you are done loading RiveScript documents")
+
+        # Get the substitution map.
+        subs = None
+        if kind == 'sub':
+            subs = self.master._sub
+        else:
+            subs = self.master._person
+
+        # Make placeholders each time we substitute something.
+        ph = []
+        i  = 0
+
+        for pattern in self.master._sorted["lists"][kind]:
+            result = subs[pattern]
+
+            # Make a placeholder.
+            ph.append(result)
+            placeholder = "\x00%d\x00" % i
+            i += 1
+
+            cache = self.master._regexc[kind][pattern]
+            msg = re.sub(cache["sub1"], placeholder, msg)
+            msg = re.sub(cache["sub2"], placeholder + r'\1', msg)
+            msg = re.sub(cache["sub3"], r'\1' + placeholder + r'\2', msg)
+            msg = re.sub(cache["sub4"], r'\1' + placeholder, msg)
+
+        placeholders = re.findall(RE.placeholder, msg)
+        for match in placeholders:
+            i = int(match)
+            result = ph[i]
+            msg = msg.replace('\x00' + match + '\x00', result)
+
+        # Strip & return.
+        return msg.strip()

--- a/rivescript/exceptions.py
+++ b/rivescript/exceptions.py
@@ -1,26 +1,9 @@
-#!/usr/bin/env python
-
-# The MIT License (MIT)
+# RiveScript-Python
 #
-# Copyright (c) 2016 Noah Petherbridge
+# This code is released under the MIT License.
+# See the "LICENSE" file for more information.
 #
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# https://www.rivescript.com/
 
 from __future__ import unicode_literals
 

--- a/rivescript/inheritance.py
+++ b/rivescript/inheritance.py
@@ -1,0 +1,144 @@
+# RiveScript-Python
+#
+# This code is released under the MIT License.
+# See the "LICENSE" file for more information.
+#
+# https://www.rivescript.com/
+
+def get_topic_triggers(rs, topic, thats, depth=0, inheritance=0, inherited=False):
+    """Recursively scan a topic and return a list of all triggers.
+
+    Arguments:
+        rs (RiveScript): A reference to the parent RiveScript instance.
+        topic (str): The original topic name.
+        thats (bool): Are we getting triggers for 'previous' replies?
+        depth (int): Recursion step counter.
+        inheritance (int): The inheritance level counter, for topics that
+            inherit other topics.
+        inherited (bool): Whether the current topic is inherited by others.
+
+    Returns:
+        []str: List of all triggers found.
+    """
+
+    # Break if we're in too deep.
+    if depth > rs._depth:
+        rs._warn("Deep recursion while scanning topic inheritance")
+
+    # Keep in mind here that there is a difference between 'includes' and
+    # 'inherits' -- topics that inherit other topics are able to OVERRIDE
+    # triggers that appear in the inherited topic. This means that if the top
+    # topic has a trigger of simply '*', then NO triggers are capable of
+    # matching in ANY inherited topic, because even though * has the lowest
+    # priority, it has an automatic priority over all inherited topics.
+    #
+    # The getTopicTriggers method takes this into account. All topics that
+    # inherit other topics will have their triggers prefixed with a fictional
+    # {inherits} tag, which would start at {inherits=0} and increment if this
+    # topic has other inheriting topics. So we can use this tag to make sure
+    # topics that inherit things will have their triggers always be on top of
+    # the stack, from inherits=0 to inherits=n.
+
+    # Important info about the depth vs inheritance params to this function:
+    # depth increments by 1 each time this function recursively calls itrs.
+    # inheritance increments by 1 only when this topic inherits another
+    # topic.
+    #
+    # This way, '> topic alpha includes beta inherits gamma' will have this
+    # effect:
+    #  alpha and beta's triggers are combined together into one matching
+    #  pool, and then those triggers have higher matching priority than
+    #  gamma's.
+    #
+    # The inherited option is True if this is a recursive call, from a topic
+    # that inherits other topics. This forces the {inherits} tag to be added
+    # to the triggers. This only applies when the top topic 'includes'
+    # another topic.
+    rs._say("\tCollecting trigger list for topic " + topic + "(depth="
+        + str(depth) + "; inheritance=" + str(inheritance) + "; "
+        + "inherited=" + str(inherited) + ")")
+
+    # topic:   the name of the topic
+    # depth:   starts at 0 and ++'s with each recursion
+
+    # Topic doesn't exist?
+    if not topic in rs._topics:
+        rs._warn("Inherited or included topic {} doesn't exist or has no triggers".format(
+            topic
+        ))
+        return []
+
+    # Collect an array of triggers to return.
+    triggers = []
+
+    # Get those that exist in this topic directly.
+    inThisTopic = []
+    if not thats:
+        # The non-that structure is {topic}->[array of triggers]
+        if topic in rs._topics:
+            for trigger in rs._topics[topic]:
+                inThisTopic.append([ trigger["trigger"], trigger ])
+    else:
+        # The 'that' structure is: {topic}->{cur trig}->{prev trig}->{trig info}
+        if topic in rs._thats.keys():
+            for curtrig in rs._thats[topic].keys():
+                for previous, pointer in rs._thats[topic][curtrig].items():
+                    inThisTopic.append([ previous, pointer ])
+
+    # Does this topic include others?
+    if topic in rs._includes:
+        # Check every included topic.
+        for includes in rs._includes[topic]:
+            rs._say("\t\tTopic " + topic + " includes " + includes)
+            triggers.extend(get_topic_triggers(rs, includes, thats, (depth + 1), inheritance, True))
+
+    # Does this topic inherit others?
+    if topic in rs._lineage:
+        # Check every inherited topic.
+        for inherits in rs._lineage[topic]:
+            rs._say("\t\tTopic " + topic + " inherits " + inherits)
+            triggers.extend(get_topic_triggers(rs, inherits, thats, (depth + 1), (inheritance + 1), False))
+
+    # Collect the triggers for *this* topic. If this topic inherits any
+    # other topics, it means that this topic's triggers have higher
+    # priority than those in any inherited topics. Enforce this with an
+    # {inherits} tag.
+    if topic in rs._lineage or inherited:
+        for trigger in inThisTopic:
+            rs._say("\t\tPrefixing trigger with {inherits=" + str(inheritance) + "}" + trigger[0])
+            triggers.append(["{inherits=" + str(inheritance) + "}" + trigger[0], trigger[1]])
+    else:
+        triggers.extend(inThisTopic)
+
+    return triggers
+
+def get_topic_tree(rs, topic, depth=0):
+    """Given one topic, get the list of all included/inherited topics.
+
+    :param str topic: The topic to start the search at.
+    :param int depth: The recursion depth counter.
+
+    :return []str: Array of topics.
+    """
+
+    # Break if we're in too deep.
+    if depth > rs._depth:
+        rs._warn("Deep recursion while scanning topic trees!")
+        return []
+
+    # Collect an array of all topics.
+    topics = [topic]
+
+    # Does this topic include others?
+    if topic in rs._includes:
+        # Try each of these.
+        for includes in sorted(rs._includes[topic]):
+            topics.extend(get_topic_tree(rs, includes, depth + 1))
+
+    # Does this topic inherit others?
+    if topic in rs._lineage:
+        # Try each of these.
+        for inherits in sorted(rs._lineage[topic]):
+            topics.extend(get_topic_tree(rs, inherits, depth + 1))
+
+    return topics

--- a/rivescript/parser.py
+++ b/rivescript/parser.py
@@ -1,0 +1,607 @@
+# RiveScript-Python
+#
+# This code is released under the MIT License.
+# See the "LICENSE" file for more information.
+#
+# https://www.rivescript.com/
+
+from .regexp import RE
+
+import re
+
+# Version of RiveScript we support.
+rs_version = 2.0
+
+class Parser(object):
+    """The RiveScript language parser.
+
+    Parameters:
+        master (RiveScript): A reference to the parent RiveScript bot instance,
+            mostly useful for its debug methods like ``warn()``.
+        strict (bool): Strict syntax checking (true by default).
+        utf8 (bool): Enable UTF-8 mode (false by default).
+    """
+
+    # Concatenation mode characters.
+    concat_modes = dict(
+        none="",
+        space=" ",
+        newline="\n",
+    )
+
+    def __init__(self, master, strict=True, utf8=False):
+        self.master = master
+        self.strict = strict
+        self.utf8   = utf8
+
+    # Proxy functions
+    def say(self, *args, **kwargs):
+        self.master._say(*args, **kwargs)
+    def warn(self, *args, **kwargs):
+        self.master._warn(*args, **kwargs)
+
+    def parse(self, filename, code):
+        """Read and parse a RiveScript document.
+
+        Returns a data structure that represents all of the useful contents of
+        the document, in this format::
+
+            {
+                "begin": { # "begin" data
+                    "global": {}, # map of !global vars
+                    "var": {},    # bot !var's
+                    "sub": {},    # !sub substitutions
+                    "person": {}, # !person substitutions
+                    "array": {},  # !array lists
+                },
+                "topics": { # main reply data
+                    "random": { # (topic name)
+                        "includes": {}, # map of included topics (values=1)
+                        "inherits": {}, # map of inherited topics
+                        "triggers": [   # array of triggers
+                            {
+                                "trigger": "hello bot",
+                                "reply": [], # array of replies
+                                "condition": [], # array of conditions
+                                "redirect": None, # redirect command
+                                "previous": None, # 'previous' reply
+                            },
+                            # ...
+                        ]
+                    }
+                }
+                "objects": [ # parsed object macros
+                    {
+                        "name": "",     # object name
+                        "language": "", # programming language
+                        "code": [],     # array of lines of code
+                    }
+                ]
+            }
+
+        Args:
+            filename (str): The name of the file that the code came from, for
+                syntax error reporting purposes.
+            code (str[]): The source code to parse.
+
+        Returns:
+            dict: The aforementioned data structure.
+        """
+
+        # Eventual returned structure ("abstract syntax tree" but not really)
+        ast = {
+            "begin": {
+                "global": {},
+                "var": {},
+                "sub": {},
+                "person": {},
+                "array": {},
+            },
+            "topics": {},
+            "objects": [],
+        }
+
+        # Track temporary variables.
+        topic   = 'random'  # Default topic=random
+        lineno  = 0         # Line numbers for syntax tracking
+        comment = False     # In a multi-line comment
+        inobj   = False     # In an object
+        objname = ''        # The name of the object we're in
+        objlang = ''        # The programming language of the object
+        objbuf  = []        # Object contents buffer
+        curtrig = None      # Pointer to the current trigger in ast.topics
+        isThat  = None      # Is a %Previous trigger
+
+        # Local (file scoped) parser options.
+        local_options = dict(
+            concat="none",  # Concat mode for ^Continue command
+        )
+
+        # Read each line.
+        for lp, line in enumerate(code):
+            lineno += 1
+
+            self.say("Line: " + line + " (topic: " + topic + ") incomment: " + str(inobj))
+            if len(line.strip()) == 0:  # Skip blank lines
+                continue
+
+            # In an object?
+            if inobj:
+                if re.match(RE.objend, line):
+                    # End the object.
+                    if len(objname):
+                        ast["objects"].append({
+                            "name": objname,
+                            "language": objlang,
+                            "code": objbuf,
+                        })
+                    objname = ''
+                    objlang = ''
+                    objbuf  = []
+                    inobj   = False
+                else:
+                    objbuf.append(line)
+                continue
+
+            line = line.strip()  # Trim excess space. We do it down here so we
+                                 # don't mess up python objects!
+
+            # Look for comments.
+            if line[:2] == '//':  # A single-line comment.
+                continue
+            elif line[0] == '#':
+                self.warn("Using the # symbol for comments is deprecated", filename, lineno)
+            elif line[:2] == '/*':  # Start of a multi-line comment.
+                if '*/' not in line:  # Cancel if the end is here too.
+                    comment = True
+                continue
+            elif '*/' in line:
+                comment = False
+                continue
+            if comment:
+                continue
+
+            # Separate the command from the data.
+            if len(line) < 2:
+                self.warn("Weird single-character line '" + line + "' found.", filename, lineno)
+                continue
+            cmd = line[0]
+            line = line[1:].strip()
+
+            # Ignore inline comments if there's a space before the // symbols.
+            if " //" in line:
+                line = line.split(" //")[0].strip()
+
+            # Run a syntax check on this line.
+            syntax_error = self.check_syntax(cmd, line)
+            if syntax_error:
+                # There was a syntax error! Are we enforcing strict mode?
+                syntax_error = "Syntax error in " + filename + " line " + str(lineno) + ": " \
+                    + syntax_error + " (near: " + cmd + " " + line + ")"
+                if self.strict:
+                    raise Exception(syntax_error)
+                else:
+                    self.warn(syntax_error)
+                    return  # Don't try to continue
+
+            # Reset the %Previous state if this is a new +Trigger.
+            if cmd == '+':
+                isThat = None
+
+            # Do a lookahead for ^Continue and %Previous commands.
+            for i in range(lp + 1, len(code)):
+                lookahead = code[i].strip()
+                if len(lookahead) < 2:
+                    continue
+                lookCmd = lookahead[0]
+                lookahead = lookahead[1:].strip()
+
+                # Only continue if the lookahead line has any data.
+                if len(lookahead) != 0:
+                    # The lookahead command has to be either a % or a ^.
+                    if lookCmd != '^' and lookCmd != '%':
+                        break
+
+                    # If the current command is a +, see if the following is
+                    # a %.
+                    if cmd == '+':
+                        if lookCmd == '%':
+                            isThat = lookahead
+                            break
+                        else:
+                            isThat = None
+
+                    # If the current command is a ! and the next command(s) are
+                    # ^, we'll tack each extension on as a line break (which is
+                    # useful information for arrays).
+                    if cmd == '!':
+                        if lookCmd == '^':
+                            line += "<crlf>" + lookahead
+                        continue
+
+                    # If the current command is not a ^ and the line after is
+                    # not a %, but the line after IS a ^, then tack it on to the
+                    # end of the current line.
+                    if cmd != '^' and lookCmd != '%':
+                        if lookCmd == '^':
+                            line += self.concat_modes.get(
+                                local_options["concat"], ""
+                            ) + lookahead
+                        else:
+                            break
+
+            self.say("Command: " + cmd + "; line: " + line)
+
+            # Handle the types of RiveScript commands.
+            if cmd == '!':
+                # ! DEFINE
+                halves = re.split(RE.equals, line, 2)
+                left = re.split(RE.ws, halves[0].strip(), 2)
+                value, type, var = '', '', ''
+                if len(halves) == 2:
+                    value = halves[1].strip()
+                if len(left) >= 1:
+                    type = left[0].strip()
+                    if len(left) >= 2:
+                        var = ' '.join(left[1:]).strip()
+
+                # Remove 'fake' line breaks unless this is an array.
+                if type != 'array':
+                    value = re.sub(RE.crlf, '', value)
+
+                # Handle version numbers.
+                if type == 'version':
+                    # Verify we support it.
+                    try:
+                        if float(value) > rs_version:
+                            self.warn("Unsupported RiveScript version. We only support " + rs_version, filename, lineno)
+                            return
+                    except:
+                        self.warn("Error parsing RiveScript version number: not a number", filename, lineno)
+                    continue
+
+                # All other types of defines require a variable and value name.
+                if len(var) == 0:
+                    self.warn("Undefined variable name", filename, lineno)
+                    continue
+                elif len(value) == 0:
+                    self.warn("Undefined variable value", filename, lineno)
+                    continue
+
+                # Handle the rest of the types.
+                if type == 'local':
+                    # Local file-scoped parser options.
+                    self.say("\tSet parser option " + var + " = " + value)
+                    local_options[var] = value
+                elif type == 'global':
+                    # 'Global' variables
+                    self.say("\tSet global " + var + " = " + value)
+
+                    if value == '<undef>':
+                        try:
+                            del(ast["begin"]["global"][var])
+                        except:
+                            self.warn("Failed to delete missing global variable", filename, lineno)
+                    else:
+                        ast["begin"]["global"][var] = value
+
+                    # Handle flipping debug and depth vars.
+                    if var == 'debug':
+                        if value.lower() == 'true':
+                            value = True
+                        else:
+                            value = False
+                    elif var == 'depth':
+                        try:
+                            value = int(value)
+                        except:
+                            self.warn("Failed to set 'depth' because the value isn't a number!", filename, lineno)
+                    elif var == 'strict':
+                        if value.lower() == 'true':
+                            value = True
+                        else:
+                            value = False
+                elif type == 'var':
+                    # Bot variables
+                    self.say("\tSet bot variable " + var + " = " + value)
+
+                    if value == '<undef>':
+                        try:
+                            del(ast["begin"]["var"][var])
+                        except:
+                            self.warn("Failed to delete missing bot variable", filename, lineno)
+                    else:
+                        ast["begin"]["var"][var] = value
+                elif type == 'array':
+                    # Arrays
+                    self.say("\tArray " + var + " = " + value)
+
+                    if value == '<undef>':
+                        try:
+                            del(ast["begin"]["array"][var])
+                        except:
+                            self.warn("Failed to delete missing array", filename, lineno)
+                        continue
+
+                    # Did this have multiple parts?
+                    parts = value.split("<crlf>")
+
+                    # Process each line of array data.
+                    fields = []
+                    for val in parts:
+                        if '|' in val:
+                            fields.extend(val.split('|'))
+                        else:
+                            fields.extend(re.split(RE.ws, val))
+
+                    # Convert any remaining '\s' escape codes into spaces.
+                    for f in fields:
+                        f = f.replace('\s', ' ')
+
+                    ast["begin"]["array"][var] = fields
+                elif type == 'sub':
+                    # Substitutions
+                    self.say("\tSubstitution " + var + " => " + value)
+
+                    if value == '<undef>':
+                        try:
+                            del(ast["begin"]["sub"][var])
+                        except:
+                            self.warn("Failed to delete missing substitution", filename, lineno)
+                    else:
+                        ast["begin"]["sub"][var] = value
+                elif type == 'person':
+                    # Person Substitutions
+                    self.say("\tPerson Substitution " + var + " => " + value)
+
+                    if value == '<undef>':
+                        try:
+                            del(ast["begin"]["person"][var])
+                        except:
+                            self.warn("Failed to delete missing person substitution", filename, lineno)
+                    else:
+                        ast["begin"]["person"][var] = value
+                else:
+                    self.warn("Unknown definition type '" + type + "'", filename, lineno)
+            elif cmd == '>':
+                # > LABEL
+                temp = re.split(RE.ws, line)
+                type   = temp[0]
+                name   = ''
+                fields = []
+                if len(temp) >= 2:
+                    name = temp[1]
+                if len(temp) >= 3:
+                    fields = temp[2:]
+
+                # Handle the label types.
+                if type == 'begin':
+                    # The BEGIN block.
+                    self.say("\tFound the BEGIN block.")
+                    type = 'topic'
+                    name = '__begin__'
+                if type == 'topic':
+                    # Starting a new topic.
+                    self.say("\tSet topic to " + name)
+                    curtrig = None
+                    topic  = name
+
+                    # Initialize the topic tree.
+                    self._init_topic(ast["topics"], topic)
+
+                    # Does this topic include or inherit another one?
+                    mode = ''  # or 'inherits' or 'includes'
+                    if len(fields) >= 2:
+                        for field in fields:
+                            if field == 'includes':
+                                mode = 'includes'
+                            elif field == 'inherits':
+                                mode = 'inherits'
+                            elif mode != '':
+                                # This topic is either inherited or included.
+                                if mode == 'includes':
+                                    ast["topics"][name]["includes"][field] = 1
+                                else:
+                                    ast["topics"][name]["inherits"][field] = 1
+                elif type == 'object':
+                    # If a field was provided, it should be the programming
+                    # language.
+                    lang = None
+                    if len(fields) > 0:
+                        lang = fields[0].lower()
+
+                    # Only try to parse a language we support.
+                    curtrig = None
+                    if lang is None:
+                        self.warn("Trying to parse unknown programming language", filename, lineno)
+                        lang = 'python'  # Assume it's Python.
+
+                    # We have a handler, so start loading the code.
+                    objname = name
+                    objlang = lang
+                    objbuf  = []
+                    inobj   = True
+                else:
+                    self.warn("Unknown label type '" + type + "'", filename, lineno)
+            elif cmd == '<':
+                # < LABEL
+                type = line
+
+                if type == 'begin' or type == 'topic':
+                    self.say("\tEnd topic label.")
+                    topic = 'random'
+                elif type == 'object':
+                    self.say("\tEnd object label.")
+                    inobj = False
+            elif cmd == '+':
+                # + TRIGGER
+                self.say("\tTrigger pattern: " + line)
+
+                # Initialize the topic tree.
+                self._init_topic(ast["topics"], topic)
+                curtrig = {
+                    "trigger": line,
+                    "reply": [],
+                    "condition": [],
+                    "redirect": None,
+                    "previous": isThat,
+                }
+                ast["topics"][topic]["triggers"].append(curtrig)
+            elif cmd == '-':
+                # - REPLY
+                if curtrig is None:
+                    self.warn("Response found before trigger", filename, lineno)
+                    continue
+
+                self.say("\tResponse: " + line)
+                curtrig["reply"].append(line.strip())
+            elif cmd == '%':
+                # % PREVIOUS
+                pass  # This was handled above.
+            elif cmd == '^':
+                # ^ CONTINUE
+                pass  # This was handled above.
+            elif cmd == '@':
+                # @ REDIRECT
+                if curtrig is None:
+                    self.warn("Redirect found before trigger", filename, lineno)
+                    continue
+
+                self.say("\tRedirect: " + line)
+                curtrig["redirect"] = line.strip()
+            elif cmd == '*':
+                # * CONDITION
+                if curtrig is None:
+                    self.warn("Condition found before trigger", filename, lineno)
+                    continue
+
+                self.say("\tAdding condition: " + line)
+                curtrig["condition"].append(line.strip())
+            else:
+                self.warn("Unrecognized command \"" + cmd + "\"", filename, lineno)
+                continue
+
+        return ast
+
+    def check_syntax(self, cmd, line):
+        """Syntax check a line of RiveScript code.
+
+        Args:
+            str cmd: The command symbol for the line of code, such as one
+                of ``+``, ``-``, ``*``, ``>``, etc.
+            str line: The remainder of the line of code, such as the text of
+                a trigger or reply.
+
+        Return:
+            str: A string syntax error message or ``None`` if no errors.
+        """
+
+        # Run syntax checks based on the type of command.
+        if cmd == '!':
+            # ! Definition
+            #   - Must be formatted like this:
+            #     ! type name = value
+            #     OR
+            #     ! type = value
+            match = re.match(RE.def_syntax, line)
+            if not match:
+                return "Invalid format for !Definition line: must be '! type name = value' OR '! type = value'"
+        elif cmd == '>':
+            # > Label
+            #   - The "begin" label must have only one argument ("begin")
+            #   - "topic" labels must be lowercased but can inherit other topics (a-z0-9_\s)
+            #   - "object" labels must follow the same rules as "topic", but don't need to be lowercase
+            parts = re.split(" ", line, 2)
+            if parts[0] == "begin" and len(parts) > 1:
+                return "The 'begin' label takes no additional arguments, should be verbatim '> begin'"
+            elif parts[0] == "topic":
+                match = re.match(RE.name_syntax, line)
+                if match:
+                    return "Topics should be lowercased and contain only numbers and letters"
+            elif parts[0] == "object":
+                match = re.match(RE.name_syntax, line)
+                if match:
+                    return "Objects can only contain numbers and letters"
+        elif cmd == '+' or cmd == '%' or cmd == '@':
+            # + Trigger, % Previous, @ Redirect
+            #   This one is strict. The triggers are to be run through the regexp engine,
+            #   therefore it should be acceptable for the regexp engine.
+            #   - Entirely lowercase
+            #   - No symbols except: ( | ) [ ] * _ # @ { } < > =
+            #   - All brackets should be matched
+            parens = 0  # Open parenthesis
+            square = 0  # Open square brackets
+            curly  = 0  # Open curly brackets
+            angle  = 0  # Open angled brackets
+
+            # Count brackets.
+            for char in line:
+                if char == '(':
+                    parens += 1
+                elif char == ')':
+                    parens -= 1
+                elif char == '[':
+                    square += 1
+                elif char == ']':
+                    square -= 1
+                elif char == '{':
+                    curly += 1
+                elif char == '}':
+                    curly -= 1
+                elif char == '<':
+                    angle += 1
+                elif char == '>':
+                    angle -= 1
+
+            # Any mismatches?
+            if parens != 0:
+                return "Unmatched parenthesis brackets"
+            elif square != 0:
+                return "Unmatched square brackets"
+            elif curly != 0:
+                return "Unmatched curly brackets"
+            elif angle != 0:
+                return "Unmatched angle brackets"
+
+            # In UTF-8 mode, most symbols are allowed.
+            if self.utf8:
+                match = re.match(RE.utf8_trig, line)
+                if match:
+                    return "Triggers can't contain uppercase letters, backslashes or dots in UTF-8 mode."
+            else:
+                match = re.match(RE.trig_syntax, line)
+                if match:
+                    return "Triggers may only contain lowercase letters, numbers, and these symbols: ( | ) [ ] * _ # @ { } < > ="
+        elif cmd == '-' or cmd == '^' or cmd == '/':
+            # - Trigger, ^ Continue, / Comment
+            # These commands take verbatim arguments, so their syntax is loose.
+            pass
+        elif cmd == '*':
+            # * Condition
+            #   Syntax for a conditional is as follows:
+            #   * value symbol value => response
+            match = re.match(RE.cond_syntax, line)
+            if not match:
+                return "Invalid format for !Condition: should be like '* value symbol value => response'"
+
+        return None
+
+    def _init_topic(self, topics, name):
+        """Initialize a Topic Tree data structure.
+
+        Sets up the topic under ``ast.topics`` with all its relevant keys
+        and sub-keys, etc.
+
+        Args:
+            topics (dict): A reference to the ``ast.topics``
+            name (str): The name of the topic to initialize.
+
+        Returns:
+            None
+        """
+        if not name in topics:
+            topics[name] = {
+                "includes": {},
+                "inherits": {},
+                "triggers": [],
+            }

--- a/rivescript/python.py
+++ b/rivescript/python.py
@@ -1,33 +1,13 @@
-#!/usr/bin/env python
-
-# The MIT License (MIT)
+# RiveScript-Python
 #
-# Copyright (c) 2016 Noah Petherbridge
+# This code is released under the MIT License.
+# See the "LICENSE" file for more information.
 #
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# https://www.rivescript.com/
 
 # Python3 compat
 from __future__ import print_function, unicode_literals
 from six import text_type
-
-__docformat__ = 'plaintext'
-
 
 class PyRiveObjects(object):
     """A RiveScript object handler for Python code.

--- a/rivescript/regexp.py
+++ b/rivescript/regexp.py
@@ -1,26 +1,9 @@
-#!/usr/bin/env python
-
-# The MIT License (MIT)
+# RiveScript-Python
 #
-# Copyright (c) 2016 Noah Petherbridge
+# This code is released under the MIT License.
+# See the "LICENSE" file for more information.
 #
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# https://www.rivescript.com/
 
 from __future__ import unicode_literals
 import re

--- a/rivescript/rivescript.py
+++ b/rivescript/rivescript.py
@@ -1,46 +1,28 @@
-#!/usr/bin/env python
-
-# The MIT License (MIT)
+# RiveScript-Python
 #
-# Copyright (c) 2016 Noah Petherbridge
+# This code is released under the MIT License.
+# See the "LICENSE" file for more information.
 #
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# https://www.rivescript.com/
 
 from __future__ import unicode_literals
 from six import text_type
 import sys
 import os
 import re
-import string
-import random
 import pprint
 import copy
 import codecs
 
 from . import __version__
 from . import python
-from .regexp import RE
+from . import sorting
+from . import inheritance as inherit_utils
+from . import utils
+from .brain import Brain
+from .parser import Parser
 from .exceptions import (
-    RS_ERR_MATCH, RS_ERR_REPLY, RS_ERR_DEEP_RECURSION, RS_ERR_OBJECT,
-    RS_ERR_OBJECT_HANDLER, RS_ERR_OBJECT_MISSING, RiveScriptError,
-    NoMatchError, NoReplyError, ObjectError, DeepRecursionError,
-    NoDefaultRandomTopicError, RepliesNotSortedError
+    RS_ERR_MATCH, RS_ERR_REPLY, RS_ERR_DEEP_RECURSION
 )
 
 # These constants come from the exceptions submodule but should be exportable
@@ -48,9 +30,6 @@ from .exceptions import (
 _ = RS_ERR_MATCH
 _ = RS_ERR_REPLY
 _ = RS_ERR_DEEP_RECURSION
-
-# Version of RiveScript we support.
-rs_version = 2.0
 
 class RiveScript(object):
     """A RiveScript interpreter for Python 2 and 3.
@@ -72,13 +51,6 @@ class RiveScript(object):
     :param bool utf8: Enable UTF-8 mode.
         The default is ``False``.
     """
-
-    # Concatenation mode characters.
-    _concat_modes = dict(
-        none="",
-        space=" ",
-        newline="\n",
-    )
 
     ############################################################################
     # Initialization and Utility Methods                                       #
@@ -106,11 +78,11 @@ class RiveScript(object):
         ###
         # Internal fields.
         ###
-        self._gvars    = {}      # 'global' variables
-        self._bvars    = {}      # 'bot' variables
-        self._subs     = {}      # 'sub' variables
+        self._global   = {}      # 'global' variables
+        self._var      = {}      # 'bot' variables
+        self._sub      = {}      # 'sub' variables
         self._person   = {}      # 'person' variables
-        self._arrays   = {}      # 'array' variables
+        self._array    = {}      # 'array' variables
         self._users    = {}      # 'user' variables
         self._freeze   = {}      # frozen 'user' variables
         self._includes = {}      # included topics
@@ -123,12 +95,21 @@ class RiveScript(object):
         self._syntax   = {}      # Syntax tracking (filenames & line no.'s)
         self._regexc   = {       # Precomputed regexes for speed optimizations.
             "trigger": {},
-            "subs":    {},
+            "sub":    {},
             "person":  {},
         }
 
-        # "Current request" variables.
-        self._current_user = None  # The current user ID.
+        # Internal helpers.
+        self._parser = Parser(
+            master=self,
+            strict=self._strict,
+            utf8=self._utf8,
+        )
+        self._brain = Brain(
+            master=self,
+            strict=self._strict,
+            utf8=self._utf8,
+        )
 
         # Define the default Python language handler.
         self._handlers["python"] = python.PyRiveObjects()
@@ -224,519 +205,63 @@ class RiveScript(object):
         :param str fname: The arbitrary file name used for syntax reporting.
         :param []str code: Lines of RiveScript source code to parse.
         """
-        self._say("Parsing code")
 
-        # Track temporary variables.
-        topic   = 'random'  # Default topic=random
-        lineno  = 0         # Line numbers for syntax tracking
-        comment = False     # In a multi-line comment
-        inobj   = False     # In an object
-        objname = ''        # The name of the object we're in
-        objlang = ''        # The programming language of the object
-        objbuf  = []        # Object contents buffer
-        ontrig  = ''        # The current trigger
-        repcnt  = 0         # Reply counter
-        concnt  = 0         # Condition counter
-        isThat  = ''        # Is a %Previous trigger
+        # Get the "abstract syntax tree"
+        ast = self._parser.parse(fname, code)
 
-        # Local (file scoped) parser options.
-        local_options = dict(
-            concat="none",  # Concat mode for ^Continue command
-        )
-
-        # Read each line.
-        for lp, line in enumerate(code):
-            lineno += 1
-
-            self._say("Line: " + line + " (topic: " + topic + ") incomment: " + str(inobj))
-            if len(line.strip()) == 0:  # Skip blank lines
-                continue
-
-            # In an object?
-            if inobj:
-                if re.match(RE.objend, line):
-                    # End the object.
-                    if len(objname):
-                        # Call the object's handler.
-                        if objlang in self._handlers:
-                            self._objlangs[objname] = objlang
-                            self._handlers[objlang].load(objname, objbuf)
-                        else:
-                            self._warn("Object creation failed: no handler for " + objlang, fname, lineno)
-                    objname = ''
-                    objlang = ''
-                    objbuf  = []
-                    inobj   = False
+        # Get all of the "begin" type variables: global, var, sub, person, ...
+        for kind, data in ast["begin"].items():
+            internal = getattr(self, "_" + kind)  # The internal name for this attribute
+            for name, value in data.items():
+                if value == "<undef>":
+                    del internal[name]
                 else:
-                    objbuf.append(line)
-                continue
+                    internal[name] = value
 
-            line = line.strip()  # Trim excess space. We do it down here so we
-                                 # don't mess up python objects!
+                # Precompile substitutions.
+                if kind in ["sub", "person"]:
+                    self._precompile_substitution(kind, name)
 
-            # Look for comments.
-            if line[:2] == '//':  # A single-line comment.
-                continue
-            elif line[0] == '#':
-                self._warn("Using the # symbol for comments is deprecated", fname, lineno)
-            elif line[:2] == '/*':  # Start of a multi-line comment.
-                if '*/' not in line:  # Cancel if the end is here too.
-                    comment = True
-                continue
-            elif '*/' in line:
-                comment = False
-                continue
-            if comment:
-                continue
+        # Let the scripts set the debug mode and other special globals.
+        if self._global.get("debug"):
+            self._debug = str(self._global["debug"]).lower() == "true"
+        if self._global.get("depth"):
+            self._depth = int(self._global["depth"])
 
-            # Separate the command from the data.
-            if len(line) < 2:
-                self._warn("Weird single-character line '" + line + "' found.", fname, lineno)
-                continue
-            cmd = line[0]
-            line = line[1:].strip()
+        # Consume all the parsed triggers.
+        for topic, data in ast["topics"].items():
+            # Keep a map of the topics that are included/inherited under this topic.
+            if not topic in self._includes:
+                self._includes[topic] = {}
+            if not topic in self._lineage:
+                self._lineage[topic] = {}
+            self._includes[topic].update(data["includes"])
+            self._lineage[topic].update(data["inherits"])
 
-            # Ignore inline comments if there's a space before and after
-            # the // symbols.
-            if " // " in line:
-                line = line.split(" // ")[0].strip()
+            # Consume the triggers.
+            if not topic in self._topics:
+                self._topics[topic] = []
+            for trigger in data["triggers"]:
+                self._topics[topic].append(trigger)
 
-            # Run a syntax check on this line.
-            syntax_error = self.check_syntax(cmd, line)
-            if syntax_error:
-                # There was a syntax error! Are we enforcing strict mode?
-                syntax_error = "Syntax error in " + fname + " line " + str(lineno) + ": " \
-                    + syntax_error + " (near: " + cmd + " " + line + ")"
-                if self._strict:
-                    raise Exception(syntax_error)
-                else:
-                    self._warn(syntax_error)
-                    return  # Don't try to continue
+                # Precompile the regexp for this trigger.
+                self._precompile_regexp(trigger["trigger"])
 
-            # Reset the %Previous state if this is a new +Trigger.
-            if cmd == '+':
-                isThat = ''
+                # Does this trigger have a %Previous? If so, make a pointer to
+                # this exact trigger in _thats.
+                if trigger["previous"] is not None:
+                    if not topic in self._thats:
+                        self._thats[topic] = {}
+                    if not trigger["trigger"] in self._thats[topic]:
+                        self._thats[topic][trigger["trigger"]] = {}
+                    self._thats[topic][trigger["trigger"]][trigger["previous"]] = trigger
 
-            # Do a lookahead for ^Continue and %Previous commands.
-            for i in range(lp + 1, len(code)):
-                lookahead = code[i].strip()
-                if len(lookahead) < 2:
-                    continue
-                lookCmd = lookahead[0]
-                lookahead = lookahead[1:].strip()
-
-                # Only continue if the lookahead line has any data.
-                if len(lookahead) != 0:
-                    # The lookahead command has to be either a % or a ^.
-                    if lookCmd != '^' and lookCmd != '%':
-                        break
-
-                    # If the current command is a +, see if the following is
-                    # a %.
-                    if cmd == '+':
-                        if lookCmd == '%':
-                            isThat = lookahead
-                            break
-                        else:
-                            isThat = ''
-
-                    # If the current command is a ! and the next command(s) are
-                    # ^, we'll tack each extension on as a line break (which is
-                    # useful information for arrays).
-                    if cmd == '!':
-                        if lookCmd == '^':
-                            line += "<crlf>" + lookahead
-                        continue
-
-                    # If the current command is not a ^ and the line after is
-                    # not a %, but the line after IS a ^, then tack it on to the
-                    # end of the current line.
-                    if cmd != '^' and lookCmd != '%':
-                        if lookCmd == '^':
-                            line += self._concat_modes.get(
-                                local_options["concat"], ""
-                            ) + lookahead
-                        else:
-                            break
-
-            self._say("Command: " + cmd + "; line: " + line)
-
-            # Handle the types of RiveScript commands.
-            if cmd == '!':
-                # ! DEFINE
-                halves = re.split(RE.equals, line, 2)
-                left = re.split(RE.ws, halves[0].strip(), 2)
-                value, type, var = '', '', ''
-                if len(halves) == 2:
-                    value = halves[1].strip()
-                if len(left) >= 1:
-                    type = left[0].strip()
-                    if len(left) >= 2:
-                        var = ' '.join(left[1:]).strip()
-
-                # Remove 'fake' line breaks unless this is an array.
-                if type != 'array':
-                    value = re.sub(RE.crlf, '', value)
-
-                # Handle version numbers.
-                if type == 'version':
-                    # Verify we support it.
-                    try:
-                        if float(value) > rs_version:
-                            self._warn("Unsupported RiveScript version. We only support " + rs_version, fname, lineno)
-                            return
-                    except:
-                        self._warn("Error parsing RiveScript version number: not a number", fname, lineno)
-                    continue
-
-                # All other types of defines require a variable and value name.
-                if len(var) == 0:
-                    self._warn("Undefined variable name", fname, lineno)
-                    continue
-                elif len(value) == 0:
-                    self._warn("Undefined variable value", fname, lineno)
-                    continue
-
-                # Handle the rest of the types.
-                if type == 'local':
-                    # Local file-scoped parser options.
-                    self._say("\tSet parser option " + var + " = " + value)
-                    local_options[var] = value
-                elif type == 'global':
-                    # 'Global' variables
-                    self._say("\tSet global " + var + " = " + value)
-
-                    if value == '<undef>':
-                        try:
-                            del(self._gvars[var])
-                        except:
-                            self._warn("Failed to delete missing global variable", fname, lineno)
-                    else:
-                        self._gvars[var] = value
-
-                    # Handle flipping debug and depth vars.
-                    if var == 'debug':
-                        if value.lower() == 'true':
-                            value = True
-                        else:
-                            value = False
-                        self._debug = value
-                    elif var == 'depth':
-                        try:
-                            self._depth = int(value)
-                        except:
-                            self._warn("Failed to set 'depth' because the value isn't a number!", fname, lineno)
-                    elif var == 'strict':
-                        if value.lower() == 'true':
-                            self._strict = True
-                        else:
-                            self._strict = False
-                elif type == 'var':
-                    # Bot variables
-                    self._say("\tSet bot variable " + var + " = " + value)
-
-                    if value == '<undef>':
-                        try:
-                            del(self._bvars[var])
-                        except:
-                            self._warn("Failed to delete missing bot variable", fname, lineno)
-                    else:
-                        self._bvars[var] = value
-                elif type == 'array':
-                    # Arrays
-                    self._say("\tArray " + var + " = " + value)
-
-                    if value == '<undef>':
-                        try:
-                            del(self._arrays[var])
-                        except:
-                            self._warn("Failed to delete missing array", fname, lineno)
-                        continue
-
-                    # Did this have multiple parts?
-                    parts = value.split("<crlf>")
-
-                    # Process each line of array data.
-                    fields = []
-                    for val in parts:
-                        if '|' in val:
-                            fields.extend(val.split('|'))
-                        else:
-                            fields.extend(re.split(RE.ws, val))
-
-                    # Convert any remaining '\s' escape codes into spaces.
-                    for f in fields:
-                        f = f.replace('\s', ' ')
-
-                    self._arrays[var] = fields
-                elif type == 'sub':
-                    # Substitutions
-                    self._say("\tSubstitution " + var + " => " + value)
-
-                    if value == '<undef>':
-                        try:
-                            del(self._subs[var])
-                        except:
-                            self._warn("Failed to delete missing substitution", fname, lineno)
-                    else:
-                        self._subs[var] = value
-
-                    # Precompile the regexp.
-                    self._precompile_substitution("subs", var)
-                elif type == 'person':
-                    # Person Substitutions
-                    self._say("\tPerson Substitution " + var + " => " + value)
-
-                    if value == '<undef>':
-                        try:
-                            del(self._person[var])
-                        except:
-                            self._warn("Failed to delete missing person substitution", fname, lineno)
-                    else:
-                        self._person[var] = value
-
-                    # Precompile the regexp.
-                    self._precompile_substitution("person", var)
-                else:
-                    self._warn("Unknown definition type '" + type + "'", fname, lineno)
-            elif cmd == '>':
-                # > LABEL
-                temp = re.split(RE.ws, line)
-                type   = temp[0]
-                name   = ''
-                fields = []
-                if len(temp) >= 2:
-                    name = temp[1]
-                if len(temp) >= 3:
-                    fields = temp[2:]
-
-                # Handle the label types.
-                if type == 'begin':
-                    # The BEGIN block.
-                    self._say("\tFound the BEGIN block.")
-                    type = 'topic'
-                    name = '__begin__'
-                if type == 'topic':
-                    # Starting a new topic.
-                    self._say("\tSet topic to " + name)
-                    ontrig = ''
-                    topic  = name
-
-                    # Does this topic include or inherit another one?
-                    mode = ''  # or 'inherits' or 'includes'
-                    if len(fields) >= 2:
-                        for field in fields:
-                            if field == 'includes':
-                                mode = 'includes'
-                            elif field == 'inherits':
-                                mode = 'inherits'
-                            elif mode != '':
-                                # This topic is either inherited or included.
-                                if mode == 'includes':
-                                    if name not in self._includes:
-                                        self._includes[name] = {}
-                                    self._includes[name][field] = 1
-                                else:
-                                    if name not in self._lineage:
-                                        self._lineage[name] = {}
-                                    self._lineage[name][field] = 1
-                elif type == 'object':
-                    # If a field was provided, it should be the programming
-                    # language.
-                    lang = None
-                    if len(fields) > 0:
-                        lang = fields[0].lower()
-
-                    # Only try to parse a language we support.
-                    ontrig = ''
-                    if lang is None:
-                        self._warn("Trying to parse unknown programming language", fname, lineno)
-                        lang = 'python'  # Assume it's Python.
-
-                    # See if we have a defined handler for this language.
-                    if lang in self._handlers:
-                        # We have a handler, so start loading the code.
-                        objname = name
-                        objlang = lang
-                        objbuf  = []
-                        inobj   = True
-                    else:
-                        # We don't have a handler, just ignore it.
-                        objname = ''
-                        objlang = ''
-                        objbuf  = []
-                        inobj   = True
-                else:
-                    self._warn("Unknown label type '" + type + "'", fname, lineno)
-            elif cmd == '<':
-                # < LABEL
-                type = line
-
-                if type == 'begin' or type == 'topic':
-                    self._say("\tEnd topic label.")
-                    topic = 'random'
-                elif type == 'object':
-                    self._say("\tEnd object label.")
-                    inobj = False
-            elif cmd == '+':
-                # + TRIGGER
-                self._say("\tTrigger pattern: " + line)
-                if len(isThat):
-                    self._initTT('thats', topic, isThat, line)
-                    self._initTT('syntax', topic, line, 'thats')
-                    self._syntax['thats'][topic][line]['trigger'] = (fname, lineno)
-                else:
-                    self._initTT('topics', topic, line)
-                    self._initTT('syntax', topic, line, 'topic')
-                    self._syntax['topic'][topic][line]['trigger'] = (fname, lineno)
-                ontrig = line
-                repcnt = 0
-                concnt = 0
-
-                # Pre-compile the trigger's regexp if possible.
-                self._precompile_regexp(ontrig)
-            elif cmd == '-':
-                # - REPLY
-                if ontrig == '':
-                    self._warn("Response found before trigger", fname, lineno)
-                    continue
-                self._say("\tResponse: " + line)
-                if len(isThat):
-                    self._thats[topic][isThat][ontrig]['reply'][repcnt] = line
-                    self._syntax['thats'][topic][ontrig]['reply'][repcnt] = (fname, lineno)
-                else:
-                    self._topics[topic][ontrig]['reply'][repcnt] = line
-                    self._syntax['topic'][topic][ontrig]['reply'][repcnt] = (fname, lineno)
-                repcnt += 1
-            elif cmd == '%':
-                # % PREVIOUS
-                pass  # This was handled above.
-            elif cmd == '^':
-                # ^ CONTINUE
-                pass  # This was handled above.
-            elif cmd == '@':
-                # @ REDIRECT
-                self._say("\tRedirect response to " + line)
-                if len(isThat):
-                    self._thats[topic][isThat][ontrig]['redirect'] = line
-                    self._syntax['thats'][topic][ontrig]['redirect'] = (fname, lineno)
-                else:
-                    self._topics[topic][ontrig]['redirect'] = line
-                    self._syntax['topic'][topic][ontrig]['redirect'] = (fname, lineno)
-            elif cmd == '*':
-                # * CONDITION
-                self._say("\tAdding condition: " + line)
-                if len(isThat):
-                    self._thats[topic][isThat][ontrig]['condition'][concnt] = line
-                    self._syntax['thats'][topic][ontrig]['condition'][concnt] = (fname, lineno)
-                else:
-                    self._topics[topic][ontrig]['condition'][concnt] = line
-                    self._syntax['topic'][topic][ontrig]['condition'][concnt] = (fname, lineno)
-                concnt += 1
-            else:
-                self._warn("Unrecognized command \"" + cmd + "\"", fname, lineno)
-                continue
-
-    def check_syntax(self, cmd, line):
-        """Syntax check a line of RiveScript code.
-
-        :param str cmd: The command symbol for the line of code, such as one
-            of ``+``, ``-``, ``*``, ``>``, etc.
-        :param str line: The remainder of the line of code, such as the text of
-            a trigger or reply.
-
-        :return: A string syntax error message or ``None`` if no errors.
-        """
-
-        # Run syntax checks based on the type of command.
-        if cmd == '!':
-            # ! Definition
-            #   - Must be formatted like this:
-            #     ! type name = value
-            #     OR
-            #     ! type = value
-            match = re.match(RE.def_syntax, line)
-            if not match:
-                return "Invalid format for !Definition line: must be '! type name = value' OR '! type = value'"
-        elif cmd == '>':
-            # > Label
-            #   - The "begin" label must have only one argument ("begin")
-            #   - "topic" labels must be lowercased but can inherit other topics (a-z0-9_\s)
-            #   - "object" labels must follow the same rules as "topic", but don't need to be lowercase
-            parts = re.split(" ", line, 2)
-            if parts[0] == "begin" and len(parts) > 1:
-                return "The 'begin' label takes no additional arguments, should be verbatim '> begin'"
-            elif parts[0] == "topic":
-                match = re.match(RE.name_syntax, line)
-                if match:
-                    return "Topics should be lowercased and contain only numbers and letters"
-            elif parts[0] == "object":
-                match = re.match(RE.name_syntax, line)
-                if match:
-                    return "Objects can only contain numbers and letters"
-        elif cmd == '+' or cmd == '%' or cmd == '@':
-            # + Trigger, % Previous, @ Redirect
-            #   This one is strict. The triggers are to be run through the regexp engine,
-            #   therefore it should be acceptable for the regexp engine.
-            #   - Entirely lowercase
-            #   - No symbols except: ( | ) [ ] * _ # @ { } < > =
-            #   - All brackets should be matched
-            parens = 0  # Open parenthesis
-            square = 0  # Open square brackets
-            curly  = 0  # Open curly brackets
-            angle  = 0  # Open angled brackets
-
-            # Count brackets.
-            for char in line:
-                if char == '(':
-                    parens += 1
-                elif char == ')':
-                    parens -= 1
-                elif char == '[':
-                    square += 1
-                elif char == ']':
-                    square -= 1
-                elif char == '{':
-                    curly += 1
-                elif char == '}':
-                    curly -= 1
-                elif char == '<':
-                    angle += 1
-                elif char == '>':
-                    angle -= 1
-
-            # Any mismatches?
-            if parens != 0:
-                return "Unmatched parenthesis brackets"
-            elif square != 0:
-                return "Unmatched square brackets"
-            elif curly != 0:
-                return "Unmatched curly brackets"
-            elif angle != 0:
-                return "Unmatched angle brackets"
-
-            # In UTF-8 mode, most symbols are allowed.
-            if self._utf8:
-                match = re.match(RE.utf8_trig, line)
-                if match:
-                    return "Triggers can't contain uppercase letters, backslashes or dots in UTF-8 mode."
-            else:
-                match = re.match(RE.trig_syntax, line)
-                if match:
-                    return "Triggers may only contain lowercase letters, numbers, and these symbols: ( | ) [ ] * _ # @ { } < > ="
-        elif cmd == '-' or cmd == '^' or cmd == '/':
-            # - Trigger, ^ Continue, / Comment
-            # These commands take verbatim arguments, so their syntax is loose.
-            pass
-        elif cmd == '*':
-            # * Condition
-            #   Syntax for a conditional is as follows:
-            #   * value symbol value => response
-            match = re.match(RE.cond_syntax, line)
-            if not match:
-                return "Invalid format for !Condition: should be like '* value symbol value => response'"
-
-        return None
+        # Load all the parsed objects.
+        for obj in ast["objects"]:
+            # Have a handler for it?
+            if obj["language"] in self._handlers:
+                self._objlangs[obj["name"]] = obj["language"]
+                self._handlers[obj["language"]].load(obj["name"], obj["code"])
 
     def deparse(self):
         """Dump the in-memory RiveScript brain as a Python data structure.
@@ -773,11 +298,11 @@ class RiveScript(object):
             result["begin"]["global"]["depth"] = 50
 
         # Definitions
-        result["begin"]["var"]    = self._bvars.copy()
-        result["begin"]["sub"]    = self._subs.copy()
+        result["begin"]["var"]    = self._var.copy()
+        result["begin"]["sub"]    = self._sub.copy()
         result["begin"]["person"] = self._person.copy()
-        result["begin"]["array"]  = self._arrays.copy()
-        result["begin"]["global"].update(self._gvars.copy())
+        result["begin"]["array"]  = self._array.copy()
+        result["begin"]["global"].update(self._global.copy())
 
         # Topic Triggers.
         for topic in self._topics:
@@ -1029,318 +554,45 @@ class RiveScript(object):
 
         return result
 
-    def _initTT(self, toplevel, topic, trigger, what=''):
-        """Initialize a Topic Tree data structure.
-
-        :param str toplevel: One of ``topics``, ``thats`` or ``syntax``
-        :param str topic: The topic name.
-        :param str trigger: The trigger text.
-        :param str what: Trigger text or ``thats`` depending on context.
-        """
-        if toplevel == 'topics':
-            if topic not in self._topics:
-                self._topics[topic] = {}
-            if trigger not in self._topics[topic]:
-                self._topics[topic][trigger]              = {}
-                self._topics[topic][trigger]['reply']     = {}
-                self._topics[topic][trigger]['condition'] = {}
-                self._topics[topic][trigger]['redirect']  = None
-        elif toplevel == 'thats':
-            if topic not in self._thats:
-                self._thats[topic] = {}
-            if trigger not in self._thats[topic]:
-                self._thats[topic][trigger] = {}
-            if what not in self._thats[topic][trigger]:
-                self._thats[topic][trigger][what] = {}
-                self._thats[topic][trigger][what]['reply']     = {}
-                self._thats[topic][trigger][what]['condition'] = {}
-                self._thats[topic][trigger][what]['redirect']  = {}
-        elif toplevel == 'syntax':
-            if what not in self._syntax:
-                self._syntax[what] = {}
-            if topic not in self._syntax[what]:
-                self._syntax[what][topic] = {}
-            if trigger not in self._syntax[what][topic]:
-                self._syntax[what][topic][trigger]              = {}
-                self._syntax[what][topic][trigger]['reply']     = {}
-                self._syntax[what][topic][trigger]['condition'] = {}
-                self._syntax[what][topic][trigger]['redirect']  = {}
-
     ############################################################################
     # Sorting Methods                                                          #
     ############################################################################
 
     def sort_replies(self, thats=False):
-        """Sort the loaded triggers.
+        """Sort the loaded triggers in memory.
 
-        Don't send any parameters when you call this function.
-
-        :param private bool thats: You shouldn't use this parameter, it's used
-            internally. Sorting is done in two passes: first the normal triggers
-            are sorted, and then triggers that have a ``%Previous`` command.
-            The ``thats`` argument is used to sort the latter, and this function
-            automatically does so, so don't worry about this argument.
+        After you have finished loading your RiveScript code, call this method
+        to populate the various internal sort buffers. This is absolutely
+        necessary for reply matching to work efficiently!
         """
-        # This method can sort both triggers and that's.
-        triglvl = None
-        sortlvl = None
-        if thats:
-            triglvl = self._thats
-            sortlvl = 'thats'
-        else:
-            triglvl = self._topics
-            sortlvl = 'topics'
-
-        # (Re)Initialize the sort cache.
-        self._sorted[sortlvl] = {}
-
+        # (Re)initialize the sort cache.
+        self._sorted["topics"] = {}
+        self._sorted["thats"]  = {}
         self._say("Sorting triggers...")
 
         # Loop through all the topics.
-        for topic in triglvl:
+        for topic in self._topics.keys():
             self._say("Analyzing topic " + topic)
 
-            # Collect a list of all the triggers we're going to need to worry
-            # about. If this topic inherits another topic, we need to
-            # recursively add those to the list.
-            alltrig = self._topic_triggers(topic, triglvl)
+            # Collect a list of all the triggers we're going to worry about.
+            # If this topic inherits another topic, we need to recursively add
+            # those to the list as well.
+            alltrig = inherit_utils.get_topic_triggers(self, topic, False)
 
-            # Keep in mind here that there is a difference between 'includes'
-            # and 'inherits' -- topics that inherit other topics are able to
-            # OVERRIDE triggers that appear in the inherited topic. This means
-            # that if the top topic has a trigger of simply '*', then *NO*
-            # triggers are capable of matching in ANY inherited topic, because
-            # even though * has the lowest sorting priority, it has an automatic
-            # priority over all inherited topics.
-            #
-            # The _topic_triggers method takes this into account. All topics
-            # that inherit other topics will have their triggers prefixed with
-            # a fictional {inherits} tag, which would start at {inherits=0} and
-            # increment if the topic tree has other inheriting topics. So we can
-            # use this tag to make sure topics that inherit things will have
-            # their triggers always be on top of the stack, from inherits=0 to
-            # inherits=n.
+            # Sort them.
+            self._sorted["topics"][topic] = sorting.sort_trigger_set(alltrig, True)
 
-            # Sort these triggers.
-            running = self._sort_trigger_set(alltrig)
+            # Get all of the %Previous triggers for this topic.
+            that_triggers = inherit_utils.get_topic_triggers(self, topic, True)
 
-            # Save this topic's sorted list.
-            if sortlvl not in self._sorted:
-                self._sorted[sortlvl] = {}
-            self._sorted[sortlvl][topic] = running
+            # And sort them, too.
+            self._sorted["thats"][topic] = sorting.sort_trigger_set(that_triggers, False)
 
-        # And do it all again for %Previous!
-        if not thats:
-            # This will sort the %Previous lines to best match the bot's last reply.
-            self.sort_replies(True)
-
-            # If any of those %Previous's had more than one +trigger for them,
-            # this will sort all those +triggers to pair back the best human
-            # interaction.
-            self._sort_that_triggers()
-
-            # Also sort both kinds of substitutions.
-            self._sort_list('subs', self._subs)
-            self._sort_list('person', self._person)
-
-    def _sort_that_triggers(self):
-        """Make a sorted list of triggers that correspond to %Previous groups."""
-        self._say("Sorting reverse triggers for %Previous groups...")
-
-        if "that_trig" not in self._sorted:
-            self._sorted["that_trig"] = {}
-
-        for topic in self._thats:
-            if topic not in self._sorted["that_trig"]:
-                self._sorted["that_trig"][topic] = {}
-
-            for bottrig in self._thats[topic]:
-                if bottrig not in self._sorted["that_trig"][topic]:
-                    self._sorted["that_trig"][topic][bottrig] = []
-                triggers = self._sort_trigger_set(self._thats[topic][bottrig].keys())
-                self._sorted["that_trig"][topic][bottrig] = triggers
-
-    def _sort_trigger_set(self, triggers):
-        """Sort a group of triggers in optimal sorting order.
-
-        The optimal sorting order is, briefly:
-        * Atomic triggers (containing nothing but plain words and alternation
-          groups) are on top, with triggers containing the most words coming
-          first. Triggers with equal word counts are sorted by length, and then
-          alphabetically if they have the same length.
-        * Triggers containing optionals are sorted next, by word count like
-          atomic triggers.
-        * Triggers containing wildcards are next, with ``_`` (alphabetic)
-          wildcards on top, then ``#`` (numeric) and finally ``*``.
-        * At the bottom of the sorted list are triggers consisting of only a
-          single wildcard, in the order: ``_``, ``#``, ``*``.
-
-        Triggers that have ``{weight}`` tags are grouped together by weight
-        value and sorted amongst themselves. Higher weighted groups are then
-        ordered before lower weighted groups regardless of the normal sorting
-        algorithm.
-
-        Triggers that come from topics which inherit other topics are also
-        sorted with higher priority than triggers from the inherited topics.
-        """
-
-        # Create a priority map.
-        prior = {
-            0: []  # Default priority=0
-        }
-
-        for trig in triggers:
-            match, weight = re.search(RE.weight, trig), 0
-            if match:
-                weight = int(match.group(1))
-            if weight not in prior:
-                prior[weight] = []
-
-            prior[weight].append(trig)
-
-        # Keep a running list of sorted triggers for this topic.
-        running = []
-
-        # Sort them by priority.
-        for p in sorted(prior.keys(), reverse=True):
-            self._say("\tSorting triggers with priority " + str(p))
-
-            # So, some of these triggers may include {inherits} tags, if they
-            # came form a topic which inherits another topic. Lower inherits
-            # values mean higher priority on the stack.
-            inherits = -1          # -1 means no {inherits} tag
-            highest_inherits = -1  # highest inheritance number seen
-
-            # Loop through and categorize these triggers.
-            track = {
-                inherits: self._init_sort_track()
-            }
-
-            for trig in prior[p]:
-                self._say("\t\tLooking at trigger: " + trig)
-
-                # See if it has an inherits tag.
-                match = re.search(RE.inherit, trig)
-                if match:
-                    inherits = int(match.group(1))
-                    if inherits > highest_inherits:
-                        highest_inherits = inherits
-                    self._say("\t\t\tTrigger belongs to a topic which inherits other topics: level=" + str(inherits))
-                    trig = re.sub(RE.inherit, "", trig)
-                else:
-                    inherits = -1
-
-                # If this is the first time we've seen this inheritance level,
-                # initialize its track structure.
-                if inherits not in track:
-                    track[inherits] = self._init_sort_track()
-
-                # Start inspecting the trigger's contents.
-                if '_' in trig:
-                    # Alphabetic wildcard included.
-                    cnt = self._word_count(trig)
-                    self._say("\t\t\tHas a _ wildcard with " + str(cnt) + " words.")
-                    if cnt > 1:
-                        if cnt not in track[inherits]['alpha']:
-                            track[inherits]['alpha'][cnt] = []
-                        track[inherits]['alpha'][cnt].append(trig)
-                    else:
-                        track[inherits]['under'].append(trig)
-                elif '#' in trig:
-                    # Numeric wildcard included.
-                    cnt = self._word_count(trig)
-                    self._say("\t\t\tHas a # wildcard with " + str(cnt) + " words.")
-                    if cnt > 1:
-                        if cnt not in track[inherits]['number']:
-                            track[inherits]['number'][cnt] = []
-                        track[inherits]['number'][cnt].append(trig)
-                    else:
-                        track[inherits]['pound'].append(trig)
-                elif '*' in trig:
-                    # Wildcard included.
-                    cnt = self._word_count(trig)
-                    self._say("\t\t\tHas a * wildcard with " + str(cnt) + " words.")
-                    if cnt > 1:
-                        if cnt not in track[inherits]['wild']:
-                            track[inherits]['wild'][cnt] = []
-                        track[inherits]['wild'][cnt].append(trig)
-                    else:
-                        track[inherits]['star'].append(trig)
-                elif '[' in trig:
-                    # Optionals included.
-                    cnt = self._word_count(trig)
-                    self._say("\t\t\tHas optionals and " + str(cnt) + " words.")
-                    if cnt not in track[inherits]['option']:
-                        track[inherits]['option'][cnt] = []
-                    track[inherits]['option'][cnt].append(trig)
-                else:
-                    # Totally atomic.
-                    cnt = self._word_count(trig)
-                    self._say("\t\t\tTotally atomic and " + str(cnt) + " words.")
-                    if cnt not in track[inherits]['atomic']:
-                        track[inherits]['atomic'][cnt] = []
-                    track[inherits]['atomic'][cnt].append(trig)
-
-            # Move the no-{inherits} triggers to the bottom of the stack.
-            track[highest_inherits + 1] = track[-1]
-            del(track[-1])
-
-            # Add this group to the sort list.
-            for ip in sorted(track.keys()):
-                self._say("ip=" + str(ip))
-                for kind in ['atomic', 'option', 'alpha', 'number', 'wild']:
-                    for wordcnt in sorted(track[ip][kind], reverse=True):
-                        # Triggers with a matching word count should be sorted
-                        # by length, descending.
-                        running.extend(sorted(track[ip][kind][wordcnt], key=len, reverse=True))
-                running.extend(sorted(track[ip]['under'], key=len, reverse=True))
-                running.extend(sorted(track[ip]['pound'], key=len, reverse=True))
-                running.extend(sorted(track[ip]['star'], key=len, reverse=True))
-        return running
-
-    def _sort_list(self, name, items):
-        """Sort a simple list by number of words and length."""
-
-        def by_length(word1, word2):
-            return len(word2) - len(word1)
-
-        # Initialize the list sort buffer.
-        if "lists" not in self._sorted:
+        # And sort the substitution lists.
+        if not "lists" in self._sorted:
             self._sorted["lists"] = {}
-        self._sorted["lists"][name] = []
-
-        # Track by number of words.
-        track = {}
-
-        # Loop through each item.
-        for item in items:
-            # Count the words.
-            cword = self._word_count(item, all=True)
-            if cword not in track:
-                track[cword] = []
-            track[cword].append(item)
-
-        # Sort them.
-        output = []
-        for count in sorted(track.keys(), reverse=True):
-            sort = sorted(track[count], key=len, reverse=True)
-            output.extend(sort)
-
-        self._sorted["lists"][name] = output
-
-    def _init_sort_track(self):
-        """Returns a new dict for keeping track of triggers for sorting."""
-        return {
-            'atomic': {},  # Sort by number of whole words
-            'option': {},  # Sort optionals by number of words
-            'alpha':  {},  # Sort alpha wildcards by no. of words
-            'number': {},  # Sort number wildcards by no. of words
-            'wild':   {},  # Sort wildcards by no. of words
-            'pound':  [],  # Triggers of just #
-            'under':  [],  # Triggers of just _
-            'star':   []   # Triggers of just *
-        }
-
+        self._sorted["lists"]["sub"] = sorting.sort_list(self._sub.keys())
+        self._sorted["lists"]["person"] = sorting.sort_list(self._person.keys())
 
     ############################################################################
     # Public Configuration Methods                                             #
@@ -1413,9 +665,9 @@ class RiveScript(object):
         """
         if value is None:
             # Unset the variable.
-            if name in self._gvars:
-                del self._gvars[name]
-        self._gvars[name] = value
+            if name in self._global:
+                del self._global[name]
+        self._global[name] = value
 
     def get_global(self, name):
         """Retrieve the current value of a global variable.
@@ -1423,7 +675,7 @@ class RiveScript(object):
         :param str name: The name of the variable to get.
         :return str: The value of the variable or ``"undefined"``.
         """
-        return self._gvars.get(name, "undefined")
+        return self._global.get(name, "undefined")
 
     def set_variable(self, name, value):
         """Set a bot variable.
@@ -1436,9 +688,9 @@ class RiveScript(object):
         """
         if value is None:
             # Unset the variable.
-            if name in self._bvars:
-                del self._bvars[name]
-        self._bvars[name] = value
+            if name in self._var:
+                del self._var[name]
+        self._var[name] = value
 
     def get_variable(self, name):
         """Retrieve the current value of a bot variable.
@@ -1446,7 +698,7 @@ class RiveScript(object):
         :param str name: The name of the variable to get.
         :return str: The value of the variable or ``"undefined"``.
         """
-        return self._bvars.get(name, "undefined")
+        return self._var.get(name, "undefined")
 
     def set_substitution(self, what, rep):
         """Set a substitution.
@@ -1744,10 +996,10 @@ class RiveScript(object):
         This will return ``None`` if used outside of the context of getting a
         reply (the value is unset at the end of the ``reply()`` method).
         """
-        if self._current_user is None:
+        if self._brain._current_user is None:
             # They're doing it wrong.
             self._warn("current_user() is meant to be used from within a Python object macro!")
-        return self._current_user
+        return self._brain._current_user
 
     ############################################################################
     # Reply Fetching Methods                                                   #
@@ -1756,446 +1008,25 @@ class RiveScript(object):
     def reply(self, user, msg, errors_as_replies=True):
         """Fetch a reply from the RiveScript brain.
 
-        :param str user: A unique user ID for the person requesting a reply.
-            This could be e.g. a screen name or nickname. It's used internally
-            to store user variables (including topic and history), so if your
-            bot has multiple users each one should have a unique ID.
-        :param str msg: The user's message. This is allowed to contain
-            punctuation and such, but any extraneous data such as HTML tags
-            should be removed in advance.
-        :param bool errors_as_replies: When errors are encountered (such as a
-            deep recursion error, no reply matched, etc.) this will make the
-            reply be a text representation of the error message. If you set
-            this to ``False``, errors will instead raise an exception, such as
-            a ``DeepRecursionError`` or ``NoReplyError``. By default, no
-            exceptions are raised and errors are set in the reply instead.
+        Arguments:
+            user (str): A unique user ID for the person requesting a reply.
+                This could be e.g. a screen name or nickname. It's used internally
+                to store user variables (including topic and history), so if your
+                bot has multiple users each one should have a unique ID.
+            msg (str): The user's message. This is allowed to contain
+                punctuation and such, but any extraneous data such as HTML tags
+                should be removed in advance.
+            errors_as_replies (bool): When errors are encountered (such as a
+                deep recursion error, no reply matched, etc.) this will make the
+                reply be a text representation of the error message. If you set
+                this to ``False``, errors will instead raise an exception, such as
+                a ``DeepRecursionError`` or ``NoReplyError``. By default, no
+                exceptions are raised and errors are set in the reply instead.
 
-        :return str: The reply output.
+        Returns:
+            str: The reply output.
         """
-        self._say("Get reply to [" + user + "] " + msg)
-
-        # Store the current user in case an object macro needs it.
-        self._current_user = user
-
-        # Format their message.
-        msg = self._format_message(msg)
-
-        reply = ''
-
-        # If the BEGIN block exists, consult it first.
-        if "__begin__" in self._topics:
-            begin = self._getreply(user, 'request', context='begin', ignore_object_errors=errors_as_replies)
-
-            # Okay to continue?
-            if '{ok}' in begin:
-                try:
-                    reply = self._getreply(user, msg, ignore_object_errors=errors_as_replies)
-                except RiveScriptError as e:
-                    if not errors_as_replies:
-                        raise
-                    reply = e.error_message
-                begin = begin.replace('{ok}', reply)
-
-            reply = begin
-
-            # Run more tag substitutions.
-            reply = self._process_tags(user, msg, reply, ignore_object_errors=errors_as_replies)
-        else:
-            # Just continue then.
-            try:
-                reply = self._getreply(user, msg, ignore_object_errors=errors_as_replies)
-            except RiveScriptError as e:
-                if not errors_as_replies:
-                    raise
-                reply = e.error_message
-
-        # Save their reply history.
-        oldInput = self._users[user]['__history__']['input'][:8]
-        self._users[user]['__history__']['input'] = [msg]
-        self._users[user]['__history__']['input'].extend(oldInput)
-        oldReply = self._users[user]['__history__']['reply'][:8]
-        self._users[user]['__history__']['reply'] = [reply]
-        self._users[user]['__history__']['reply'].extend(oldReply)
-
-        # Unset the current user.
-        self._current_user = None
-
-        return reply
-
-    def _format_message(self, msg, botreply=False):
-        """Format a user's message for safe processing.
-
-        This runs substitutions on the message and strips out any remaining
-        symbols (depending on UTF-8 mode).
-
-        :param str msg: The user's message.
-        :param bool botreply: Whether this formatting is being done for the
-            bot's last reply (e.g. in a ``%Previous`` command).
-
-        :return str: The formatted message.
-        """
-
-        # Make sure the string is Unicode for Python 2.
-        if sys.version_info[0] < 3 and isinstance(msg, str):
-            msg = msg.decode()
-
-        # Lowercase it.
-        msg = msg.lower()
-
-        # Run substitutions on it.
-        msg = self._substitute(msg, "subs")
-
-        # In UTF-8 mode, only strip metacharacters and HTML brackets
-        # (to protect from obvious XSS attacks).
-        if self._utf8:
-            msg = re.sub(RE.utf8_meta, '', msg)
-            msg = re.sub(self.unicode_punctuation, '', msg)
-
-            # For the bot's reply, also strip common punctuation.
-            if botreply:
-                msg = re.sub(RE.utf8_punct, '', msg)
-        else:
-            # For everything else, strip all non-alphanumerics.
-            msg = self._strip_nasties(msg)
-
-        return msg
-
-    def _getreply(self, user, msg, context='normal', step=0, ignore_object_errors=True):
-        """The internal reply getter function.
-
-        DO NOT CALL THIS YOURSELF.
-
-        :param str user: The user ID as passed to ``reply()``.
-        :param str msg: The formatted user message.
-        :param str context: The reply context, one of ``begin`` or ``normal``.
-        :param int step: The recursion depth counter.
-        :param bool ignore_object_errors: Whether to ignore errors from within
-            Python object macros and not raise an ``ObjectError`` exception.
-
-        :return str: The reply output.
-        """
-        # Needed to sort replies?
-        if 'topics' not in self._sorted:
-            raise RepliesNotSortedError("You must call sort_replies() once you are done loading RiveScript documents")
-
-        # Initialize the user's profile?
-        if user not in self._users:
-            self._users[user] = {'topic': 'random'}
-
-        # Collect data on the user.
-        topic     = self._users[user]['topic']
-        stars     = []
-        thatstars = []  # For %Previous's.
-        reply     = ''
-
-        # Avoid letting them fall into a missing topic.
-        if topic not in self._topics:
-            self._warn("User " + user + " was in an empty topic named '" + topic + "'")
-            topic = self._users[user]['topic'] = 'random'
-
-        # Avoid deep recursion.
-        if step > self._depth:
-            raise DeepRecursionError
-
-        # Are we in the BEGIN statement?
-        if context == 'begin':
-            topic = '__begin__'
-
-        # Initialize this user's history.
-        if '__history__' not in self._users[user]:
-            self._users[user]['__history__'] = {
-                'input': [
-                    'undefined', 'undefined', 'undefined', 'undefined',
-                    'undefined', 'undefined', 'undefined', 'undefined',
-                    'undefined'
-                ],
-                'reply': [
-                    'undefined', 'undefined', 'undefined', 'undefined',
-                    'undefined', 'undefined', 'undefined', 'undefined',
-                    'undefined'
-                ]
-            }
-
-        # More topic sanity checking.
-        if topic not in self._topics:
-            # This was handled before, which would mean topic=random and
-            # it doesn't exist. Serious issue!
-            raise NoDefaultRandomTopicError("no default topic 'random' was found")
-
-        # Create a pointer for the matched data when we find it.
-        matched        = None
-        matchedTrigger = None
-        foundMatch     = False
-
-        # See if there were any %Previous's in this topic, or any topic related
-        # to it. This should only be done the first time -- not during a
-        # recursive redirection. This is because in a redirection, "lastreply"
-        # is still gonna be the same as it was the first time, causing an
-        # infinite loop!
-        if step == 0:
-            allTopics = [topic]
-            if topic in self._includes or topic in self._lineage:
-                # Get all the topics!
-                allTopics = self._get_topic_tree(topic)
-
-            # Scan them all!
-            for top in allTopics:
-                self._say("Checking topic " + top + " for any %Previous's.")
-                if top in self._sorted["thats"]:
-                    self._say("There is a %Previous in this topic!")
-
-                    # Do we have history yet?
-                    lastReply = self._users[user]["__history__"]["reply"][0]
-
-                    # Format the bot's last reply the same way as the human's.
-                    lastReply = self._format_message(lastReply, botreply=True)
-
-                    self._say("lastReply: " + lastReply)
-
-                    # See if it's a match.
-                    for trig in self._sorted["thats"][top]:
-                        botside = self._reply_regexp(user, trig)
-                        self._say("Try to match lastReply (" + lastReply + ") to " + trig)
-
-                        # Match??
-                        match = re.match(botside, lastReply)
-                        if match:
-                            # Huzzah! See if OUR message is right too.
-                            self._say("Bot side matched!")
-                            thatstars = match.groups()
-                            for subtrig in self._sorted["that_trig"][top][trig]:
-                                humanside = self._reply_regexp(user, subtrig)
-                                self._say("Now try to match " + msg + " to " + subtrig)
-
-                                match = re.match(humanside, msg)
-                                if match:
-                                    self._say("Found a match!")
-                                    matched = self._thats[top][trig][subtrig]
-                                    matchedTrigger = subtrig
-                                    foundMatch = True
-
-                                    # Get the stars!
-                                    stars = match.groups()
-                                    break
-
-                        # Break if we found a match.
-                        if foundMatch:
-                            break
-                # Break if we found a match.
-                if foundMatch:
-                    break
-
-        # Search their topic for a match to their trigger.
-        if not foundMatch:
-            for trig in self._sorted["topics"][topic]:
-                # Process the triggers.
-                regexp = self._reply_regexp(user, trig)
-                self._say("Try to match %r against %r (%r)" % (msg, trig, regexp.pattern))
-
-                # Python's regular expression engine is slow. Try a verbatim
-                # match if this is an atomic trigger.
-                isAtomic = self._is_atomic(trig)
-                isMatch = False
-                if isAtomic:
-                    # Only look for exact matches, no sense running atomic triggers
-                    # through the regexp engine.
-                    if msg == trig:
-                        isMatch = True
-                else:
-                    # Non-atomic triggers always need the regexp.
-                    match = re.match(regexp, msg)
-                    if match:
-                        # The regexp matched!
-                        isMatch = True
-
-                        # Collect the stars.
-                        stars = match.groups()
-
-                if isMatch:
-                    self._say("Found a match!")
-
-                    # We found a match, but what if the trigger we've matched
-                    # doesn't belong to our topic? Find it!
-                    if trig not in self._topics[topic]:
-                        # We have to find it.
-                        matched = self._find_trigger_by_inheritance(topic, trig)
-                    else:
-                        # We do have it!
-                        matched = self._topics[topic][trig]
-
-                    foundMatch = True
-                    matchedTrigger = trig
-                    break
-
-        # Store what trigger they matched on. If their matched trigger is None,
-        # this will be too, which is great.
-        self._users[user]["__lastmatch__"] = matchedTrigger
-
-        if matched:
-            for nil in [1]:
-                # See if there are any hard redirects.
-                if matched["redirect"]:
-                    self._say("Redirecting us to " + matched["redirect"])
-                    redirect = self._process_tags(user, msg, matched["redirect"], stars, thatstars, step,
-                                                  ignore_object_errors)
-                    self._say("Pretend user said: " + redirect)
-                    reply = self._getreply(user, redirect, step=(step + 1), ignore_object_errors=ignore_object_errors)
-                    break
-
-                # Check the conditionals.
-                for con in sorted(matched["condition"]):
-                    halves = re.split(RE.cond_split, matched["condition"][con])
-                    if halves and len(halves) == 2:
-                        condition = re.match(RE.cond_parse, halves[0])
-                        if condition:
-                            left     = condition.group(1)
-                            eq       = condition.group(2)
-                            right    = condition.group(3)
-                            potreply = halves[1]
-                            self._say("Left: " + left + "; eq: " + eq + "; right: " + right + " => " + potreply)
-
-                            # Process tags all around.
-                            left  = self._process_tags(user, msg, left, stars, thatstars, step, ignore_object_errors)
-                            right = self._process_tags(user, msg, right, stars, thatstars, step, ignore_object_errors)
-
-                            # Defaults?
-                            if len(left) == 0:
-                                left = 'undefined'
-                            if len(right) == 0:
-                                right = 'undefined'
-
-                            self._say("Check if " + left + " " + eq + " " + right)
-
-                            # Validate it.
-                            passed = False
-                            if eq == 'eq' or eq == '==':
-                                if left == right:
-                                    passed = True
-                            elif eq == 'ne' or eq == '!=' or eq == '<>':
-                                if left != right:
-                                    passed = True
-                            else:
-                                # Gasp, dealing with numbers here...
-                                try:
-                                    left, right = int(left), int(right)
-                                    if eq == '<':
-                                        if left < right:
-                                            passed = True
-                                    elif eq == '<=':
-                                        if left <= right:
-                                            passed = True
-                                    elif eq == '>':
-                                        if left > right:
-                                            passed = True
-                                    elif eq == '>=':
-                                        if left >= right:
-                                            passed = True
-                                except:
-                                    self._warn("Failed to evaluate numeric condition!")
-
-                            # How truthful?
-                            if passed:
-                                reply = potreply
-                                break
-
-                # Have our reply yet?
-                if len(reply) > 0:
-                    break
-
-                # Process weights in the replies.
-                bucket = []
-                for rep in sorted(matched["reply"]):
-                    text = matched["reply"][rep]
-                    weight = 1
-                    match  = re.match(RE.weight, text)
-                    if match:
-                        weight = int(match.group(1))
-                        if weight <= 0:
-                            self._warn("Can't have a weight <= 0!")
-                            weight = 1
-                    for i in range(0, weight):
-                        bucket.append(text)
-
-                # Get a random reply.
-                reply = random.choice(bucket)
-                break
-
-        # Still no reply?
-        if not foundMatch:
-            raise NoMatchError
-        elif len(reply) == 0:
-            raise NoReplyError
-
-        self._say("Reply: " + reply)
-
-        # Process tags for the BEGIN block.
-        if context == "begin":
-            # BEGIN blocks can only set topics and uservars. The rest happen
-            # later!
-            reTopic = re.findall(RE.topic_tag, reply)
-            for match in reTopic:
-                self._say("Setting user's topic to " + match)
-                self._users[user]["topic"] = match
-                reply = reply.replace('{{topic={match}}}'.format(match=match), '')
-
-            reSet = re.findall(RE.set_tag, reply)
-            for match in reSet:
-                self._say("Set uservar " + str(match[0]) + "=" + str(match[1]))
-                self._users[user][match[0]] = match[1]
-                reply = reply.replace('<set {key}={value}>'.format(key=match[0], value=match[1]), '')
-        else:
-            # Process more tags if not in BEGIN.
-            reply = self._process_tags(user, msg, reply, stars, thatstars, step, ignore_object_errors)
-
-        return reply
-
-    def _substitute(self, msg, kind):
-        """Run a kind of substitution on a message.
-
-        :param str msg: The message to run substitutions against.
-        :param str kind: The kind of substitution to run,
-            one of ``subs`` or ``person``.
-        """
-
-        # Safety checking.
-        if 'lists' not in self._sorted:
-            raise RepliesNotSortedError("You must call sort_replies() once you are done loading RiveScript documents")
-        if kind not in self._sorted["lists"]:
-            raise RepliesNotSortedError("You must call sort_replies() once you are done loading RiveScript documents")
-
-        # Get the substitution map.
-        subs = None
-        if kind == 'subs':
-            subs = self._subs
-        else:
-            subs = self._person
-
-        # Make placeholders each time we substitute something.
-        ph = []
-        i  = 0
-
-        for pattern in self._sorted["lists"][kind]:
-            result = subs[pattern]
-
-            # Make a placeholder.
-            ph.append(result)
-            placeholder = "\x00%d\x00" % i
-            i += 1
-
-            cache = self._regexc[kind][pattern]
-            msg = re.sub(cache["sub1"], placeholder, msg)
-            msg = re.sub(cache["sub2"], placeholder + r'\1', msg)
-            msg = re.sub(cache["sub3"], r'\1' + placeholder + r'\2', msg)
-            msg = re.sub(cache["sub4"], r'\1' + placeholder, msg)
-
-        placeholders = re.findall(RE.placeholder, msg)
-        for match in placeholders:
-            i = int(match)
-            result = ph[i]
-            msg = msg.replace('\x00' + match + '\x00', result)
-
-        # Strip & return.
-        return msg.strip()
+        return self._brain.reply(user, msg, errors_as_replies)
 
     def _precompile_substitution(self, kind, pattern):
         """Pre-compile the regexp for a substitution pattern.
@@ -2217,129 +1048,6 @@ class RiveScript(object):
                 "sub4": re.compile(r'(\W+)' + qm + r'$'),
             }
 
-    def _do_expand_array(self, array_name, depth=0):
-        """Do recurrent array expansion, returning a set of keywords.
-
-        Exception is thrown when there are cyclical dependencies between
-        arrays or if the ``@array`` name references an undefined array.
-
-        :param str array_name: The name of the array to expand.
-        :param int depth: The recursion depth counter.
-
-        :return set: The final set of array entries.
-        """
-        if depth > self._depth:
-            raise Exception("deep recursion detected")
-        if not array_name in self._arrays:
-            raise Exception("array '%s' not defined" % (array_name))
-        ret = list(self._arrays[array_name])
-        for array in self._arrays[array_name]:
-            if array.startswith('@'):
-                ret.remove(array)
-                expanded = self._do_expand_array(array[1:], depth+1)
-                ret.extend(expanded)
-
-        return set(ret)
-
-    def _expand_array(self, array_name):
-        """Expand variables and return a set of keywords.
-
-        :param str array_name: The name of the array to expand.
-
-        :return list: The final array contents.
-
-        Warning is issued when exceptions occur."""
-        ret = self._arrays[array_name] if array_name in self._arrays else []
-        try:
-            ret = self._do_expand_array(array_name)
-        except Exception as e:
-            self._warn("Error expanding array '%s': %s" % (array_name, str(e)))
-        return ret
-
-
-    def _reply_regexp(self, user, regexp):
-        """Prepares a trigger for the regular expression engine.
-
-        :param str user: The user ID invoking a reply.
-        :param str regexp: The original trigger text to be turned into a regexp.
-
-        :return regexp: The final regexp object."""
-
-        if regexp in self._regexc["trigger"]:
-            # Already compiled this one!
-            return self._regexc["trigger"][regexp]
-
-        # If the trigger is simply '*' then the * there needs to become (.*?)
-        # to match the blank string too.
-        regexp = re.sub(RE.zero_star, r'<zerowidthstar>', regexp)
-
-        # Simple replacements.
-        regexp = regexp.replace('*', '(.+?)')   # Convert * into (.+?)
-        regexp = regexp.replace('#', '(\d+?)')  # Convert # into (\d+?)
-        regexp = regexp.replace('_', '(\w+?)')  # Convert _ into (\w+?)
-        regexp = re.sub(r'\{weight=\d+\}', '', regexp)  # Remove {weight} tags
-        regexp = regexp.replace('<zerowidthstar>', r'(.*?)')
-
-        # Optionals.
-        optionals = re.findall(RE.optionals, regexp)
-        for match in optionals:
-            parts = match.split("|")
-            new = []
-            for p in parts:
-                p = r'(?:\\s|\\b)+{}(?:\\s|\\b)+'.format(p)
-                new.append(p)
-
-            # If this optional had a star or anything in it, make it
-            # non-matching.
-            pipes = '|'.join(new)
-            pipes = pipes.replace(r'(.+?)', r'(?:.+?)')
-            pipes = pipes.replace(r'(\d+?)', r'(?:\d+?)')
-            pipes = pipes.replace(r'([A-Za-z]+?)', r'(?:[A-Za-z]+?)')
-
-            regexp = re.sub(r'\s*\[' + re.escape(match) + '\]\s*',
-                '(?:' + pipes + r'|(?:\\s|\\b))', regexp)
-
-        # _ wildcards can't match numbers!
-        regexp = re.sub(RE.literal_w, r'[A-Za-z]', regexp)
-
-        # Filter in arrays.
-        arrays = re.findall(RE.array, regexp)
-        for array in arrays:
-            rep = ''
-            if array in self._arrays:
-                rep = r'(?:' + '|'.join(self._expand_array(array)) + ')'
-            regexp = re.sub(r'\@' + re.escape(array) + r'\b', rep, regexp)
-
-        # Filter in bot variables.
-        bvars = re.findall(RE.bot_tag, regexp)
-        for var in bvars:
-            rep = ''
-            if var in self._bvars:
-                rep = self._strip_nasties(self._bvars[var])
-            regexp = regexp.replace('<bot {var}>'.format(var=var), rep)
-
-        # Filter in user variables.
-        uvars = re.findall(RE.get_tag, regexp)
-        for var in uvars:
-            rep = ''
-            if var in self._users[user]:
-                rep = self._strip_nasties(self._users[user][var])
-            regexp = regexp.replace('<get {var}>'.format(var=var), rep)
-
-        # Filter in <input> and <reply> tags. This is a slow process, so only
-        # do it if we have to!
-        if '<input' in regexp or '<reply' in regexp:
-            for type in ['input', 'reply']:
-                tags = re.findall(r'<' + type + r'([0-9])>', regexp)
-                for index in tags:
-                    rep = self._format_message(self._users[user]['__history__'][type][int(index) - 1])
-                    regexp = regexp.replace('<{type}{index}>'.format(type=type, index=index), rep)
-                regexp = regexp.replace('<{type}>'.format(type=type),
-                                        self._format_message(self._users[user]['__history__'][type][0]))
-                # TODO: the Perl version doesn't do just <input>/<reply> in trigs!
-
-        return re.compile(r'^' + regexp + r'$')
-
     def _precompile_regexp(self, trigger):
         """Precompile the regex for most triggers.
 
@@ -2349,7 +1057,7 @@ class RiveScript(object):
 
         :param str trigger: The trigger text to attempt to precompile.
         """
-        if self._is_atomic(trigger):
+        if utils.is_atomic(trigger):
             return  # Don't need a regexp for atomic triggers.
 
         # Check for dynamic tags.
@@ -2357,467 +1065,11 @@ class RiveScript(object):
             if tag in trigger:
                 return  # Can't precompile this trigger.
 
-        self._regexc["trigger"][trigger] = self._reply_regexp(None, trigger)
-
-    def _process_tags(self, user, msg, reply, st=[], bst=[], depth=0, ignore_object_errors=True):
-        """Post process tags in a message.
-
-        :param str user: The user ID.
-        :param str msg: The user's formatted message.
-        :param str reply: The raw RiveScript reply for the message.
-        :param []str st: The array of ``<star>`` matches from the trigger.
-        :param []str bst: The array of ``<botstar>`` matches from a
-            ``%Previous`` command.
-        :param int depth: The recursion depth counter.
-        :param bool ignore_object_errors: Whether to ignore errors in Python
-            object macros instead of raising an ``ObjectError`` exception.
-
-        :return str: The final reply after tags have been processed.
-        """
-        stars = ['']
-        stars.extend(st)
-        botstars = ['']
-        botstars.extend(bst)
-        if len(stars) == 1:
-            stars.append("undefined")
-        if len(botstars) == 1:
-            botstars.append("undefined")
-
-        # Tag shortcuts.
-        reply = reply.replace('<person>', '{person}<star>{/person}')
-        reply = reply.replace('<@>', '{@<star>}')
-        reply = reply.replace('<formal>', '{formal}<star>{/formal}')
-        reply = reply.replace('<sentence>', '{sentence}<star>{/sentence}')
-        reply = reply.replace('<uppercase>', '{uppercase}<star>{/uppercase}')
-        reply = reply.replace('<lowercase>', '{lowercase}<star>{/lowercase}')
-
-        # Weight and <star> tags.
-        reply = re.sub(RE.weight, '', reply)  # Leftover {weight}s
-        if len(stars) > 0:
-            reply = reply.replace('<star>', stars[1])
-            reStars = re.findall(RE.star_tags, reply)
-            for match in reStars:
-                if int(match) < len(stars):
-                    reply = reply.replace('<star{match}>'.format(match=match), stars[int(match)])
-        if len(botstars) > 0:
-            reply = reply.replace('<botstar>', botstars[1])
-            reStars = re.findall(RE.botstars, reply)
-            for match in reStars:
-                if int(match) < len(botstars):
-                    reply = reply.replace('<botstar{match}>'.format(match=match), botstars[int(match)])
-
-        # <input> and <reply>
-        reply = reply.replace('<input>', self._users[user]['__history__']['input'][0])
-        reply = reply.replace('<reply>', self._users[user]['__history__']['reply'][0])
-        reInput = re.findall(RE.input_tags, reply)
-        for match in reInput:
-            reply = reply.replace('<input{match}>'.format(match=match),
-                                  self._users[user]['__history__']['input'][int(match) - 1])
-        reReply = re.findall(RE.reply_tags, reply)
-        for match in reReply:
-            reply = reply.replace('<reply{match}>'.format(match=match),
-                                  self._users[user]['__history__']['reply'][int(match) - 1])
-
-        # <id> and escape codes.
-        reply = reply.replace('<id>', user)
-        reply = reply.replace('\\s', ' ')
-        reply = reply.replace('\\n', "\n")
-        reply = reply.replace('\\#', '#')
-
-        # Random bits.
-        reRandom = re.findall(RE.random_tags, reply)
-        for match in reRandom:
-            output = ''
-            if '|' in match:
-                output = random.choice(match.split('|'))
-            else:
-                output = random.choice(match.split(' '))
-            reply = reply.replace('{{random}}{match}{{/random}}'.format(match=match), output)
-
-        # Person Substitutions and String Formatting.
-        for item in ['person', 'formal', 'sentence', 'uppercase',  'lowercase']:
-            matcher = re.findall(r'\{' + item + r'\}(.+?)\{/' + item + r'\}', reply)
-            for match in matcher:
-                output = None
-                if item == 'person':
-                    # Person substitutions.
-                    output = self._substitute(match, "person")
-                else:
-                    output = self._string_format(match, item)
-                reply = reply.replace('{{{item}}}{match}{{/{item}}}'.format(item=item, match=match), output)
-
-        # Handle all variable-related tags with an iterative regex approach,
-        # to allow for nesting of tags in arbitrary ways (think <set a=<get b>>)
-        # Dummy out the <call> tags first, because we don't handle them right
-        # here.
-        reply = reply.replace("<call>", "{__call__}")
-        reply = reply.replace("</call>", "{/__call__}")
-        while True:
-            # This regex will match a <tag> which contains no other tag inside
-            # it, i.e. in the case of <set a=<get b>> it will match <get b> but
-            # not the <set> tag, on the first pass. The second pass will get the
-            # <set> tag, and so on.
-            match = re.search(RE.tag_search, reply)
-            if not match: break  # No remaining tags!
-
-            match = match.group(1)
-            parts  = match.split(" ", 1)
-            tag    = parts[0].lower()
-            data   = parts[1] if len(parts) > 1 else ""
-            insert = ""  # Result of the tag evaluation
-
-            # Handle the tags.
-            if tag == "bot" or tag == "env":
-                # <bot> and <env> tags are similar.
-                target = self._bvars if tag == "bot" else self._gvars
-                if "=" in data:
-                    # Setting a bot/env variable.
-                    parts = data.split("=")
-                    self._say("Set " + tag + " variable " + text_type(parts[0]) + "=" + text_type(parts[1]))
-                    target[parts[0]] = parts[1]
-                else:
-                    # Getting a bot/env variable.
-                    insert = target.get(data, "undefined")
-            elif tag == "set":
-                # <set> user vars.
-                parts = data.split("=")
-                self._say("Set uservar " + text_type(parts[0]) + "=" + text_type(parts[1]))
-                self._users[user][parts[0]] = parts[1]
-            elif tag in ["add", "sub", "mult", "div"]:
-                # Math operator tags.
-                parts = data.split("=")
-                var   = parts[0]
-                value = parts[1]
-
-                # Sanity check the value.
-                try:
-                    value = int(value)
-                    if var not in self._users[user]:
-                        # Initialize it.
-                        self._users[user][var] = 0
-                except:
-                    insert = "[ERR: Math can't '{}' non-numeric value '{}']".format(tag, value)
-
-                # Attempt the operation.
-                try:
-                    orig = int(self._users[user][var])
-                    new  = 0
-                    if tag == "add":
-                        new = orig + value
-                    elif tag == "sub":
-                        new = orig - value
-                    elif tag == "mult":
-                        new = orig * value
-                    elif tag == "div":
-                        new = orig / value
-                    self._users[user][var] = new
-                except:
-                    insert = "[ERR: Math couldn't '{}' to value '{}']".format(tag, self._users[user][var])
-            elif tag == "get":
-                insert = self._users[user].get(data, "undefined")
-            else:
-                # Unrecognized tag.
-                insert = "\x00{}\x01".format(match)
-
-            reply = reply.replace("<{}>".format(match), insert)
-
-        # Restore unrecognized tags.
-        reply = reply.replace("\x00", "<").replace("\x01", ">")
-
-        # Streaming code. DEPRECATED!
-        if '{!' in reply:
-            self._warn("Use of the {!...} tag is deprecated and not supported here.")
-
-        # Topic setter.
-        reTopic = re.findall(RE.topic_tag, reply)
-        for match in reTopic:
-            self._say("Setting user's topic to " + match)
-            self._users[user]["topic"] = match
-            reply = reply.replace('{{topic={match}}}'.format(match=match), '')
-
-        # Inline redirecter.
-        reRedir = re.findall(RE.redir_tag, reply)
-        for match in reRedir:
-            self._say("Redirect to " + match)
-            at = match.strip()
-            subreply = self._getreply(user, at, step=(depth + 1))
-            reply = reply.replace('{{@{match}}}'.format(match=match), subreply)
-
-        # Object caller.
-        reply = reply.replace("{__call__}", "<call>")
-        reply = reply.replace("{/__call__}", "</call>")
-        reCall = re.findall(r'<call>(.+?)</call>', reply)
-        for match in reCall:
-            parts  = re.split(RE.ws, match)
-            output = ''
-            obj    = parts[0]
-            args   = []
-            if len(parts) > 1:
-                args = parts[1:]
-
-            # Do we know this object?
-            if obj in self._objlangs:
-                # We do, but do we have a handler for that language?
-                lang = self._objlangs[obj]
-                if lang in self._handlers:
-                    # We do.
-                    try:
-                        output = self._handlers[lang].call(self, obj, user, args)
-                    except python.PythonObjectError as e:
-                        self._warn(str(e))
-                        if not ignore_object_errors:
-                            raise ObjectError(str(e))
-                        output = RS_ERR_OBJECT
-                else:
-                    if not ignore_object_errors:
-                        raise ObjectError(RS_ERR_OBJECT_HANDLER)
-                    output = RS_ERR_OBJECT_HANDLER
-            else:
-                if not ignore_object_errors:
-                    raise ObjectError(RS_ERR_OBJECT_MISSING)
-                output = RS_ERR_OBJECT_MISSING
-
-            reply = reply.replace('<call>{match}</call>'.format(match=match), output)
-
-        return reply
-
-    def _string_format(self, msg, method):
-        """Format a string (upper, lower, formal, sentence).
-
-        :param str msg: The user's message.
-        :param str method: One of ``uppercase``, ``lowercase``,
-            ``sentence`` or ``formal``.
-
-        :return str: The reformatted string.
-        """
-        if method == "uppercase":
-            return msg.upper()
-        elif method == "lowercase":
-            return msg.lower()
-        elif method == "sentence":
-            return msg.capitalize()
-        elif method == "formal":
-            return string.capwords(msg)
-
-    ############################################################################
-    # Topic inheritance Utility Methods                                        #
-    ############################################################################
-
-    def _topic_triggers(self, topic, triglvl, depth=0, inheritance=0, inherited=False):
-        """Recursively scan a topic and return a list of all triggers.
-
-        :param str topic: The original topic name.
-        :param dict triglvl: A reference to where the triggers are located,
-            e.g. normal triggers vs. ones with ``%Previous``.
-        :param int depth: The recursion depth counter.
-        :param int inheritance: The inheritance level counter, for topics that
-            inherit other topics.
-        :param bool inherited: Whether the current topic is inherited by others.
-
-        :return []str: List of all triggers found.
-        """
-
-        # Break if we're in too deep.
-        if depth > self._depth:
-            self._warn("Deep recursion while scanning topic inheritance")
-
-        # Important info about the depth vs inheritance params to this function:
-        # depth increments by 1 each time this function recursively calls itself.
-        # inheritance increments by 1 only when this topic inherits another
-        # topic.
-        #
-        # This way, '> topic alpha includes beta inherits gamma' will have this
-        # effect:
-        #  alpha and beta's triggers are combined together into one matching
-        #  pool, and then those triggers have higher matching priority than
-        #  gamma's.
-        #
-        # The inherited option is True if this is a recursive call, from a topic
-        # that inherits other topics. This forces the {inherits} tag to be added
-        # to the triggers. This only applies when the top topic 'includes'
-        # another topic.
-        self._say("\tCollecting trigger list for topic " + topic + "(depth="
-            + str(depth) + "; inheritance=" + str(inheritance) + "; "
-            + "inherited=" + str(inherited) + ")")
-
-        # topic:   the name of the topic
-        # triglvl: reference to self._topics or self._thats
-        # depth:   starts at 0 and ++'s with each recursion
-
-        # Collect an array of triggers to return.
-        triggers = []
-
-        # Get those that exist in this topic directly.
-        inThisTopic = []
-        if topic in triglvl:
-            for trigger in triglvl[topic]:
-                inThisTopic.append(trigger)
-
-        # Does this topic include others?
-        if topic in self._includes:
-            # Check every included topic.
-            for includes in self._includes[topic]:
-                self._say("\t\tTopic " + topic + " includes " + includes)
-                triggers.extend(self._topic_triggers(includes, triglvl, (depth + 1), inheritance, True))
-
-        # Does this topic inherit others?
-        if topic in self._lineage:
-            # Check every inherited topic.
-            for inherits in self._lineage[topic]:
-                self._say("\t\tTopic " + topic + " inherits " + inherits)
-                triggers.extend(self._topic_triggers(inherits, triglvl, (depth + 1), (inheritance + 1), False))
-
-        # Collect the triggers for *this* topic. If this topic inherits any
-        # other topics, it means that this topic's triggers have higher
-        # priority than those in any inherited topics. Enforce this with an
-        # {inherits} tag.
-        if topic in self._lineage or inherited:
-            for trigger in inThisTopic:
-                self._say("\t\tPrefixing trigger with {inherits=" + str(inheritance) + "}" + trigger)
-                triggers.append("{inherits=" + str(inheritance) + "}" + trigger)
-        else:
-            triggers.extend(inThisTopic)
-
-        return triggers
-
-    def _find_trigger_by_inheritance(self, topic, trig, depth=0):
-        """Locate the replies for a trigger in an inherited/included topic.
-
-        :param str topic: The topic to search in.
-        :param str trig: The trigger we're looking for.
-        :param int depth: The recursion depth counter.
-
-        :return dict: The trigger's details.
-        """
-
-        # This sub was called because the user matched a trigger from the sorted
-        # array, but the trigger doesn't belong to their topic, and is instead
-        # in an inherited or included topic. This is to search for it.
-
-        # Prevent recursion.
-        if depth > self._depth:
-            self._warn("Deep recursion detected while following an inheritance trail!")
-            return None
-
-        # inheritance is more important than inclusion: triggers in one topic can
-        # override those in an inherited topic.
-        if topic in self._lineage:
-            for inherits in sorted(self._lineage[topic]):
-                # See if this inherited topic has our trigger.
-                if trig in self._topics[inherits]:
-                    # Great!
-                    return self._topics[inherits][trig]
-                else:
-                    # Check what THAT topic inherits from.
-                    match = self._find_trigger_by_inheritance(
-                        inherits, trig, (depth + 1)
-                    )
-                    if match:
-                        # Found it!
-                        return match
-
-        # See if this topic has an "includes"
-        if topic in self._includes:
-            for includes in sorted(self._includes[topic]):
-                # See if this included topic has our trigger.
-                if trig in self._topics[includes]:
-                    # Great!
-                    return self._topics[includes][trig]
-                else:
-                    # Check what THAT topic inherits from.
-                    match = self._find_trigger_by_inheritance(
-                        includes, trig, (depth + 1)
-                    )
-                    if match:
-                        # Found it!
-                        return match
-
-        # Don't know what else to do!
-        return None
-
-    def _get_topic_tree(self, topic, depth=0):
-        """Given one topic, get the list of all included/inherited topics.
-
-        :param str topic: The topic to start the search at.
-        :param int depth: The recursion depth counter.
-
-        :return []str: Array of topics.
-        """
-
-        # Break if we're in too deep.
-        if depth > self._depth:
-            self._warn("Deep recursion while scanning topic trees!")
-            return []
-
-        # Collect an array of all topics.
-        topics = [topic]
-
-        # Does this topic include others?
-        if topic in self._includes:
-            # Try each of these.
-            for includes in sorted(self._includes[topic]):
-                topics.extend(self._get_topic_tree(includes, depth + 1))
-
-        # Does this topic inherit others?
-        if topic in self._lineage:
-            # Try each of these.
-            for inherits in sorted(self._lineage[topic]):
-                topics.extend(self._get_topic_tree(inherits, depth + 1))
-
-        return topics
+        self._regexc["trigger"][trigger] = self._brain.reply_regexp(None, trigger)
 
     ############################################################################
     # Miscellaneous Private Methods                                            #
     ############################################################################
-
-    def _is_atomic(self, trigger):
-        """Determine if a trigger is atomic or not.
-
-        In this context we're deciding whether or not the trigger needs to use
-        the regular expression engine for testing. So any trigger that contains
-        nothing but plain words is considered atomic, whereas a trigger with any
-        "regexp-like" parts (even alternations) is not.
-
-        :param trigger: The trigger to test.
-
-        :return bool: Whether it's atomic or not.
-        """
-
-        # Atomic triggers don't contain any wildcards or parenthesis or anything
-        # of the sort. We don't need to test the full character set, just left
-        # brackets will do.
-        special = ['*', '#', '_', '(', '[', '<', '@']
-        for char in special:
-            if char in trigger:
-                return False
-
-        return True
-
-    def _word_count(self, trigger, all=False):
-        """Count the words that aren't wildcards in a trigger.
-
-        :param str trigger: The trigger to count words for.
-        :param bool all: Count purely based on whitespace separators, or
-            consider wildcards not to be their own words.
-
-        :return int: The word count."""
-        words = []
-        if all:
-            words = re.split(RE.ws, trigger)
-        else:
-            words = re.split(RE.wilds, trigger)
-
-        wc = 0  # Word count
-        for word in words:
-            if len(word) > 0:
-                wc += 1
-
-        return wc
-
-    def _strip_nasties(self, s):
-        """Formats a string for ASCII regex matching."""
-        s = re.sub(RE.nasties, '', s)
-        return s
 
     def _dump(self):
         """For debugging, dump the entire data structure."""
@@ -2825,15 +1077,15 @@ class RiveScript(object):
 
         print("=== Variables ===")
         print("-- Globals --")
-        pp.pprint(self._gvars)
+        pp.pprint(self._global)
         print("-- Bot vars --")
-        pp.pprint(self._bvars)
+        pp.pprint(self._var)
         print("-- Substitutions --")
-        pp.pprint(self._subs)
+        pp.pprint(self._sub)
         print("-- Person Substitutions --")
         pp.pprint(self._person)
         print("-- Arrays --")
-        pp.pprint(self._arrays)
+        pp.pprint(self._array)
 
         print("=== Topic Structure ===")
         pp.pprint(self._topics)

--- a/rivescript/sorting.py
+++ b/rivescript/sorting.py
@@ -1,0 +1,203 @@
+# RiveScript-Python
+#
+# This code is released under the MIT License.
+# See the "LICENSE" file for more information.
+#
+# https://www.rivescript.com/
+
+from .regexp import RE
+from . import utils
+import re
+
+def sort_trigger_set(triggers, exclude_previous=True, say=None):
+    """Sort a group of triggers in optimal sorting order.
+
+    The optimal sorting order is, briefly:
+    * Atomic triggers (containing nothing but plain words and alternation
+      groups) are on top, with triggers containing the most words coming
+      first. Triggers with equal word counts are sorted by length, and then
+      alphabetically if they have the same length.
+    * Triggers containing optionals are sorted next, by word count like
+      atomic triggers.
+    * Triggers containing wildcards are next, with ``_`` (alphabetic)
+      wildcards on top, then ``#`` (numeric) and finally ``*``.
+    * At the bottom of the sorted list are triggers consisting of only a
+      single wildcard, in the order: ``_``, ``#``, ``*``.
+
+    Triggers that have ``{weight}`` tags are grouped together by weight
+    value and sorted amongst themselves. Higher weighted groups are then
+    ordered before lower weighted groups regardless of the normal sorting
+    algorithm.
+
+    Triggers that come from topics which inherit other topics are also
+    sorted with higher priority than triggers from the inherited topics.
+
+    Arguments:
+        triggers ([]str): Array of triggers to sort.
+        exclude_previous (bool): Create a sort buffer for 'previous' triggers.
+        say (function): A reference to ``RiveScript._say()`` or provide your
+            own function.
+    """
+    if say is None:
+        say = lambda x: x
+
+    # KEEP IN MIND: the `triggers` array is composed of array elements of the form
+    # ["trigger text", pointer to trigger data]
+    # So this code will use e.g. `trig[0]` when referring to the trigger text.
+
+    # Create a priority map.
+    prior = {
+        0: []  # Default priority=0
+    }
+
+    for trig in triggers:
+        if exclude_previous and trig[1]["previous"]:
+            continue
+
+        match, weight = re.search(RE.weight, trig[0]), 0
+        if match:
+            weight = int(match.group(1))
+        if weight not in prior:
+            prior[weight] = []
+
+        prior[weight].append(trig)
+
+    # Keep a running list of sorted triggers for this topic.
+    running = []
+
+    # Sort them by priority.
+    for p in sorted(prior.keys(), reverse=True):
+        say("\tSorting triggers with priority " + str(p))
+
+        # So, some of these triggers may include {inherits} tags, if they
+        # came form a topic which inherits another topic. Lower inherits
+        # values mean higher priority on the stack.
+        inherits = -1          # -1 means no {inherits} tag
+        highest_inherits = -1  # highest inheritance number seen
+
+        # Loop through and categorize these triggers.
+        track = {
+            inherits: init_sort_track()
+        }
+
+        for trig in prior[p]:
+            pattern = trig[0]
+            say("\t\tLooking at trigger: " + pattern)
+
+            # See if it has an inherits tag.
+            match = re.search(RE.inherit, pattern)
+            if match:
+                inherits = int(match.group(1))
+                if inherits > highest_inherits:
+                    highest_inherits = inherits
+                say("\t\t\tTrigger belongs to a topic which inherits other topics: level=" + str(inherits))
+                pattern = re.sub(RE.inherit, "", pattern)
+                trig[0] = pattern
+            else:
+                inherits = -1
+
+            # If this is the first time we've seen this inheritance level,
+            # initialize its track structure.
+            if inherits not in track:
+                track[inherits] = init_sort_track()
+
+            # Start inspecting the trigger's contents.
+            if '_' in pattern:
+                # Alphabetic wildcard included.
+                cnt = utils.word_count(pattern)
+                say("\t\t\tHas a _ wildcard with " + str(cnt) + " words.")
+                if cnt > 1:
+                    if cnt not in track[inherits]['alpha']:
+                        track[inherits]['alpha'][cnt] = []
+                    track[inherits]['alpha'][cnt].append(trig)
+                else:
+                    track[inherits]['under'].append(trig)
+            elif '#' in pattern:
+                # Numeric wildcard included.
+                cnt = utils.word_count(pattern)
+                say("\t\t\tHas a # wildcard with " + str(cnt) + " words.")
+                if cnt > 1:
+                    if cnt not in track[inherits]['number']:
+                        track[inherits]['number'][cnt] = []
+                    track[inherits]['number'][cnt].append(trig)
+                else:
+                    track[inherits]['pound'].append(trig)
+            elif '*' in pattern:
+                # Wildcard included.
+                cnt = utils.word_count(pattern)
+                say("\t\t\tHas a * wildcard with " + str(cnt) + " words.")
+                if cnt > 1:
+                    if cnt not in track[inherits]['wild']:
+                        track[inherits]['wild'][cnt] = []
+                    track[inherits]['wild'][cnt].append(trig)
+                else:
+                    track[inherits]['star'].append(trig)
+            elif '[' in pattern:
+                # Optionals included.
+                cnt = utils.word_count(pattern)
+                say("\t\t\tHas optionals and " + str(cnt) + " words.")
+                if cnt not in track[inherits]['option']:
+                    track[inherits]['option'][cnt] = []
+                track[inherits]['option'][cnt].append(trig)
+            else:
+                # Totally atomic.
+                cnt = utils.word_count(pattern)
+                say("\t\t\tTotally atomic and " + str(cnt) + " words.")
+                if cnt not in track[inherits]['atomic']:
+                    track[inherits]['atomic'][cnt] = []
+                track[inherits]['atomic'][cnt].append(trig)
+
+        # Move the no-{inherits} triggers to the bottom of the stack.
+        track[highest_inherits + 1] = track[-1]
+        del(track[-1])
+
+        # Add this group to the sort list.
+        for ip in sorted(track.keys()):
+            say("ip=" + str(ip))
+            for kind in ['atomic', 'option', 'alpha', 'number', 'wild']:
+                for wordcnt in sorted(track[ip][kind], reverse=True):
+                    # Triggers with a matching word count should be sorted
+                    # by length, descending.
+                    running.extend(sorted(track[ip][kind][wordcnt], key=len, reverse=True))
+            running.extend(sorted(track[ip]['under'], key=len, reverse=True))
+            running.extend(sorted(track[ip]['pound'], key=len, reverse=True))
+            running.extend(sorted(track[ip]['star'], key=len, reverse=True))
+    return running
+
+def sort_list(items):
+    """Sort a simple list by number of words and length."""
+
+    # Track by number of words.
+    track = {}
+
+    def by_length(word1, word2):
+        return len(word2) - len(word1)
+
+    # Loop through each item.
+    for item in items:
+        # Count the words.
+        cword = utils.word_count(item, all=True)
+        if cword not in track:
+            track[cword] = []
+        track[cword].append(item)
+
+    # Sort them.
+    output = []
+    for count in sorted(track.keys(), reverse=True):
+        sort = sorted(track[count], key=len, reverse=True)
+        output.extend(sort)
+
+    return output
+
+def init_sort_track():
+    """Returns a new dict for keeping track of triggers for sorting."""
+    return {
+        'atomic': {},  # Sort by number of whole words
+        'option': {},  # Sort optionals by number of words
+        'alpha':  {},  # Sort alpha wildcards by no. of words
+        'number': {},  # Sort number wildcards by no. of words
+        'wild':   {},  # Sort wildcards by no. of words
+        'pound':  [],  # Triggers of just #
+        'under':  [],  # Triggers of just _
+        'star':   []   # Triggers of just *
+    }

--- a/rivescript/utils.py
+++ b/rivescript/utils.py
@@ -1,0 +1,77 @@
+# RiveScript-Python
+#
+# This code is released under the MIT License.
+# See the "LICENSE" file for more information.
+#
+# https://www.rivescript.com/
+
+from .regexp import RE
+import re
+import string
+
+def word_count(trigger, all=False):
+    """Count the words that aren't wildcards in a trigger.
+
+    :param str trigger: The trigger to count words for.
+    :param bool all: Count purely based on whitespace separators, or
+        consider wildcards not to be their own words.
+
+    :return int: The word count."""
+    words = []
+    if all:
+        words = re.split(RE.ws, trigger)
+    else:
+        words = re.split(RE.wilds, trigger)
+
+    wc = 0  # Word count
+    for word in words:
+        if len(word) > 0:
+            wc += 1
+
+    return wc
+
+def is_atomic(trigger):
+    """Determine if a trigger is atomic or not.
+
+    In this context we're deciding whether or not the trigger needs to use
+    the regular expression engine for testing. So any trigger that contains
+    nothing but plain words is considered atomic, whereas a trigger with any
+    "regexp-like" parts (even alternations) is not.
+
+    :param trigger: The trigger to test.
+
+    :return bool: Whether it's atomic or not.
+    """
+
+    # Atomic triggers don't contain any wildcards or parenthesis or anything
+    # of the sort. We don't need to test the full character set, just left
+    # brackets will do.
+    special = ['*', '#', '_', '(', '[', '<', '@']
+    for char in special:
+        if char in trigger:
+            return False
+
+    return True
+
+def strip_nasties(s):
+    """Formats a string for ASCII regex matching."""
+    s = re.sub(RE.nasties, '', s)
+    return s
+
+def string_format(msg, method):
+    """Format a string (upper, lower, formal, sentence).
+
+    :param str msg: The user's message.
+    :param str method: One of ``uppercase``, ``lowercase``,
+        ``sentence`` or ``formal``.
+
+    :return str: The reformatted string.
+    """
+    if method == "uppercase":
+        return msg.upper()
+    elif method == "lowercase":
+        return msg.lower()
+    elif method == "sentence":
+        return msg.capitalize()
+    elif method == "formal":
+        return string.capwords(msg)

--- a/shell.py
+++ b/shell.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+"""shell.py: a shortcut to running RiveScript in interactive mode.
+
+Running this script is equivalent to running `python rivescript` and it
+accepts all the same parameters. This script is provided as a convenience
+in case running the RiveScript module as a script is inconvenient (e.g.
+when it's installed as a system module at some long path under
+/usr/lib/python/...)"""
+
+from rivescript.interactive import interactive_mode
+
+if __name__ == "__main__":
+    interactive_mode()


### PR DESCRIPTION
This brings a long-needed code structure update to the Python version to put it on par with what the JS and Go versions are doing.

```
      .   .       
     .:...::      RiveScript Interpreter (Python)
    .::   ::.     Library Version: v1.13.0
 ..:;;. ' .;;:..  
    .  '''  .     Type '/quit' to quit.
     :;,:,;:      Type '/help' for more options.
     :     :      

Using the RiveScript bot found in: eg/brain
Type a message to the bot and press Return to send it.

You> hello bot
Bot> How do you do. Please state your problem.
```

## Testing

You can install this branch with pip:

```
pip install https://github.com/aichaos/rivescript-python/archive/feature/code-restructure.zip
```

## Code Reorganization

This mostly breaks the monolithic `rivescript.py` into a handful of smaller, more focused pieces, and moves some functions around.

* `rivescript.parser` now contains all the parsing logic used under the hood by functions like `load_file()` and `stream()`. Its `parse()` function is decoupled from RiveScript (apart from debug log methods) and it returns a data structure of what was parsed from the file. This may be useful to third-party developers if they just want to parse RiveScript code.
* `rivescript.brain` now holds the logic for actually fetching a reply for the user. This includes the implementation of the `reply()` method and helper functions (tag processing, input message formatting, regexp compiling)
* `rivescript.inheritance` includes utility functions for crawling the inheritance tree to find triggers.
* `rivescript.sorting` includes the functions for sorting replies.
* `rivescript.utils` has the miscellaneous internal utility functions.

The biggest change is with regards to how triggers are stored internally. The old way had the `self._topics` structure contain a bunch of nested dictionaries, with keys like:

```python
_topics = {
  "random": {
    "hello bot": {
      "reply": { "0": "Hello human!" },
      "redirect": "",
      # etc
    }
  }
}
```

This way had problems such as how to handle duplicate triggers and it made it messier to keep track of triggers that had `%Previous` tags apart from those that do not. The new way keeps the triggers in an array, and includes a pointer to the trigger's data along with the text itself (no needing to do separate lookups! For example, there used to be a `thattrig` map that correlated `%Previous` triggers with their data locations... and the inheritance functions used to have a method of `find_trigger_by_inheritance` and that's no longer needed either).

It now looks more like:
```python
_topics = {
  "random": [ # array of triggers! duplicates technically allowed
    {
      "trigger": "hello bot",
      "reply": [ # the reply is a simple array, not a fake array hash map!
            "Hello human!"
      ],
      "redirect": None,
      # etc.
    },
    # more triggers...
  ]
}
```

## API Shuffling

Some functions were moved out of the `rivescript.rivescript` module and into their own, more relevant spots. Other functions were no longer needed and were removed.

Most of these were internal, private use functions that you shouldn't have been using anyway, but here's the complete list:

* `rivescript.rs_version` attribute now belongs to `brain.rs_version`
* `_initTT()` is now in `sorting.init_topic()` and does a lot less work.
* `_sort_that_triggers()` is removed.
* `_sort_trigger_set()` is moved to `sorting.sort_trigger_set()`
* `_sort_list()` is moved to `sorting.sort_list()`
* `_init_sort_track()` is moved to `sorting.init_sort_track()`
* `_format_message()`, `_getreply()`, `_substitute()`, `_do_expand_array()`, `_expand_array()`, `_reply_regexp()`, `_process_tags()` and the implementation of `reply()` have all been moved to `rivescript.brain`
* `_string_format`, `_word_count`, `_is_atomic` and `_strip_nasties` are all moved to `utils`
* `_topic_triggers` is now in `rivescript.inheritance.get_topic_triggers`
* `_find_trigger_by_inheritance` is removed.
* `_get_topic_tree` is now in `rivesript.inheritance.get_topic_tree`

## Other Changes

* Refactor the `rivescript.interactive` script to use `argparse` instead of `getopt` and add a pretty logo.
* Add a `shell.py` as an (easier?) way to invoke the interactive mode.

## Things To Do

At some point in the future I want to:

* Break unit tests apart into smaller more focused files like the JS version.
* Put the `deparse()` and related functions into its own module
* Rename `rivescript.python` as something like `rivescript.lang.python` for consistency with the other implementations.
* Revisit all docstrings and rewrite them in [Google style](http://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).