### PR TITLE
Fix a regression supporting Unicode in Python 2

### DIFF
--- a/rivescript/brain.py
+++ b/rivescript/brain.py
@@ -5,6 +5,7 @@
 #
 # https://www.rivescript.com/
 
+from __future__ import unicode_literals
 from .regexp import RE
 from .exceptions import (
     RiveScriptError, RepliesNotSortedError, NoDefaultRandomTopicError,

--- a/rivescript/interactive.py
+++ b/rivescript/interactive.py
@@ -11,7 +11,7 @@ import argparse
 import json
 import re
 from six.moves import input
-from six import text_type
+from six import text_type, PY2
 
 from rivescript import RiveScript
 
@@ -245,6 +245,9 @@ def interactive_mode():
 
     while True:
         msg = input("You> ")
+        if PY2:
+            # For Python 2 only: cast the message to Unicode.
+            msg = msg.decode("utf-8")
 
         # Commands
         if msg == '/help':

--- a/rivescript/parser.py
+++ b/rivescript/parser.py
@@ -5,6 +5,7 @@
 #
 # https://www.rivescript.com/
 
+from __future__ import unicode_literals
 from .regexp import RE
 
 import re

--- a/rivescript/sorting.py
+++ b/rivescript/sorting.py
@@ -5,6 +5,7 @@
 #
 # https://www.rivescript.com/
 
+from __future__ import unicode_literals
 from .regexp import RE
 from . import utils
 import re

--- a/rivescript/utils.py
+++ b/rivescript/utils.py
@@ -5,6 +5,7 @@
 #
 # https://www.rivescript.com/
 
+from __future__ import unicode_literals
 from .regexp import RE
 import re
 import string

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -20,6 +20,12 @@ class UnicodeTest(RiveScriptTestCase):
             + ブラッキー
             - エーフィ
 
+            + my favorite game is *
+            - <set game=<formal>>When did you first start playing <get game>?
+
+            + what is my favorite game
+            - Wasn't it <get game>?
+
             // Make sure %Previous continues working in UTF-8 mode.
             + knock knock
             - Who's there?
@@ -51,6 +57,8 @@ class UnicodeTest(RiveScriptTestCase):
 
         self.reply("äh", "What's the matter?")
         self.reply("ブラッキー", "エーフィ")
+        self.reply("My favorite game is Pokémon", "When did you first start playing Pokémon?")
+        self.reply("What is my favorite game?", "Wasn't it Pokémon?")
         self.reply("knock knock", "Who's there?")
         self.reply("Orange", "Orange who?")
         self.reply("banana", "Haha! Banana!")


### PR DESCRIPTION
After reorganizing the code in #30, some of the new Python modules stopped importing `unicode_literals` which broke cases where Unicode strings were interpolated into quoted strings.

Additionally, the interactive mode needed to decode the user's input message *only for Python 2* because it was an ASCII string by default when it needed to be Unicode. Under Python 3 the string is already Unicode.

This also adds a unit test that put a Unicode message into a user variable via `<set>/<get>` tags which verifies that this change fixed it under Python 2, where the new unit test initially failed.