### PR TITLE
Fix sorting algorithm for %Previous triggers

### DIFF
--- a/rivescript/brain.py
+++ b/rivescript/brain.py
@@ -576,17 +576,17 @@ class Brain(object):
         # Weight and <star> tags.
         reply = re.sub(RE.weight, '', reply)  # Leftover {weight}s
         if len(stars) > 0:
-            reply = reply.replace('<star>', stars[1])
+            reply = reply.replace('<star>', text_type(stars[1]))
             reStars = re.findall(RE.star_tags, reply)
             for match in reStars:
                 if int(match) < len(stars):
-                    reply = reply.replace('<star{match}>'.format(match=match), stars[int(match)])
+                    reply = reply.replace('<star{match}>'.format(match=match), text_type(stars[int(match)]))
         if len(botstars) > 0:
             reply = reply.replace('<botstar>', botstars[1])
             reStars = re.findall(RE.botstars, reply)
             for match in reStars:
                 if int(match) < len(botstars):
-                    reply = reply.replace('<botstar{match}>'.format(match=match), botstars[int(match)])
+                    reply = reply.replace('<botstar{match}>'.format(match=match), text_type(botstars[int(match)]))
 
         # <input> and <reply>
         history = self.master.get_uservar(user, "__history__")

--- a/rivescript/brain.py
+++ b/rivescript/brain.py
@@ -15,7 +15,6 @@ from .exceptions import (
 from . import python
 from . import inheritance as inherit_utils
 from . import utils
-import random
 import re
 from six import text_type
 import sys
@@ -385,7 +384,7 @@ class Brain(object):
                         bucket.append(text)
 
                 # Get a random reply.
-                reply = random.choice(bucket)
+                reply = utils.random_choice(bucket)
                 break
 
         # Still no reply?
@@ -614,9 +613,9 @@ class Brain(object):
         for match in reRandom:
             output = ''
             if '|' in match:
-                output = random.choice(match.split('|'))
+                output = utils.random_choice(match.split('|'))
             else:
-                output = random.choice(match.split(' '))
+                output = utils.random_choice(match.split(' '))
             reply = reply.replace('{{random}}{match}{{/random}}'.format(match=match), output)
 
         # Person Substitutions and String Formatting.

--- a/rivescript/brain.py
+++ b/rivescript/brain.py
@@ -226,7 +226,7 @@ class Brain(object):
 
                     # See if it's a match.
                     for trig in self.master._sorted["thats"][top]:
-                        pattern = trig[0]
+                        pattern = trig[1]["previous"]
                         botside = self.reply_regexp(user, pattern)
                         self.say("Try to match lastReply (" + lastReply + ") to " + pattern)
 

--- a/rivescript/inheritance.py
+++ b/rivescript/inheritance.py
@@ -83,7 +83,7 @@ def get_topic_triggers(rs, topic, thats, depth=0, inheritance=0, inherited=False
         if topic in rs._thats.keys():
             for curtrig in rs._thats[topic].keys():
                 for previous, pointer in rs._thats[topic][curtrig].items():
-                    inThisTopic.append([ previous, pointer ])
+                    inThisTopic.append([ pointer["trigger"], pointer ])
 
     # Does this topic include others?
     if topic in rs._includes:

--- a/rivescript/interactive.py
+++ b/rivescript/interactive.py
@@ -26,9 +26,10 @@ def json_in(bot, buffer, stateful):
     # Decode the incoming JSON.
     try:
         incoming = json.loads(buffer)
-    except:
+    except Exception as e:
         resp['status'] = 'error'
         resp['reply'] = 'Failed to decode incoming JSON data.'
+        resp['error'] = text_type(e)
         print(json.dumps(resp))
         if stateful:
             print("__END__")

--- a/rivescript/rivescript.py
+++ b/rivescript/rivescript.py
@@ -595,13 +595,13 @@ class RiveScript(object):
             alltrig = inherit_utils.get_topic_triggers(self, topic, False)
 
             # Sort them.
-            self._sorted["topics"][topic] = sorting.sort_trigger_set(alltrig, True)
+            self._sorted["topics"][topic] = sorting.sort_trigger_set(alltrig, True, self._say)
 
             # Get all of the %Previous triggers for this topic.
             that_triggers = inherit_utils.get_topic_triggers(self, topic, True)
 
             # And sort them, too.
-            self._sorted["thats"][topic] = sorting.sort_trigger_set(that_triggers, False)
+            self._sorted["thats"][topic] = sorting.sort_trigger_set(that_triggers, False, self._say)
 
         # And sort the substitution lists.
         if not "lists" in self._sorted:

--- a/rivescript/utils.py
+++ b/rivescript/utils.py
@@ -7,6 +7,7 @@
 
 from __future__ import unicode_literals
 from .regexp import RE
+import random
 import re
 import string
 
@@ -76,3 +77,19 @@ def string_format(msg, method):
         return msg.capitalize()
     elif method == "formal":
         return string.capwords(msg)
+
+def random_choice(bucket):
+    """Safely get a random choice from a list.
+
+    If the list is zero-length, this just returns an empty string rather than
+    raise an exception.
+
+    Parameters:
+        bucket (list): A list to randomly choose from.
+
+    Returns:
+        str: The random choice. Blank string if the list was empty.
+    """
+    if len(bucket) == 0:
+        return ""
+    return random.choice(bucket)


### PR DESCRIPTION
This fixes #59 and other bugs that had come up WRT the sorting algorithm for triggers with `%Previous`.

## Root Problem

The sorting algorithm was sorting triggers with `%Previous` incorrectly, using the text of their `%` command as the sort key rather than the trigger. So, when you had two triggers with a matching `%Previous` command, the ordering of the user-facing triggers were non-deterministic. See #59 for an example.

## The Fix

The `inheritance.get_topic_tree()` function was returning triggers in the format `[ previous, pointer]` where `previous` is the `%Previous` text. It should have returned triggers in the same format as normal ones: `[ trigger, pointer]`

And in the reply fetching process, when it compares the trigger's `%Previous` with the bot's previous message, it was using that first key from `get_topic_tree` (which *used* to be the text of the `%Previous` but now is the trigger text, per the previous paragraph), so I made it look at `pointer["previous"]` instead as it should.

-----

## Misc Fixes

This will also fix #54 and fix #51 by adding more safety around `<star>` substitutions so as not to crash Python.

And it will fix #36 by calling `random.choice` more safely so as not to break when the list of choices is empty.