### PR TITLE
Feature tolerate the space between text and the weight tag.

### DIFF
--- a/rivescript/brain.py
+++ b/rivescript/brain.py
@@ -437,7 +437,7 @@ class Brain(object):
         regexp = regexp.replace('*', '(.+?)')   # Convert * into (.+?)
         regexp = regexp.replace('#', '(\d+?)')  # Convert # into (\d+?)
         regexp = regexp.replace('_', '(\w+?)')  # Convert _ into (\w+?)
-        regexp = re.sub(r'\{weight=\d+\}', '', regexp)  # Remove {weight} tags
+        regexp = re.sub(r'\s*\{weight=\d+\}', '', regexp)  # Remove {weight} tags, allow spaces before the bracket
         regexp = regexp.replace('<zerowidthstar>', r'(.*?)')
 
         # Optionals.


### PR DESCRIPTION
Earlier the code with weight like this would fail to capture any input because of the space between weight tag and the remaining of the text. This is because all input messages are stripped of trailing space (denote by underscore): `hi_`->`hi`. But the removal of weight tag removes the tag only and the trailing space of the remaining text is left not removed, the trigger is still `hi_`. 
```
+hi {weight=1}
-hello
```