### PR TITLE
Fix #86 and allow continue ^ in triggers

### DIFF
--- a/rivescript/parser.py
+++ b/rivescript/parser.py
@@ -215,6 +215,7 @@ class Parser(object):
                     continue
                 lookCmd = lookahead[0]
                 lookahead = lookahead[1:].strip()
+                lookahead = re.sub(RE.space, ' ', lookahead)  # Replace the `\s` in the message
 
                 # Only continue if the lookahead line has any data.
                 if len(lookahead) != 0:

--- a/rivescript/regexp.py
+++ b/rivescript/regexp.py
@@ -14,6 +14,7 @@ import re
 class RE(object):
     equals      = re.compile('\s*=\s*')
     ws          = re.compile('\s+')
+    space       = re.compile('\\\\s')
     objend      = re.compile('^\s*<\s*object')
     weight      = re.compile(r'\s*\{weight=(\d+)\}\s*')
     inherit     = re.compile('\{inherits=(\d+)\}')

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -36,6 +36,18 @@ class ParserOptionTest(RiveScriptTestCase):
             - Hello
             ^ world!
 
+            ! local concat = none
+            + test concat
+            ^ in trigger
+            - Hello
+            ^ world!
+
+            ! local concat = none
+            + [test] concat
+            ^ \sin trigger with space and optional
+            - Hello
+            ^ \sworld!
+
             // the option is file scoped so it can be left at
             // any setting and won't affect subsequent parses
             ! local concat = newline
@@ -53,3 +65,5 @@ class ParserOptionTest(RiveScriptTestCase):
         self.reply("test concat none", "Helloworld!")
         self.reply("test concat newline", "Hello\nworld!")
         self.reply("test concat second file", "Helloworld!")
+        self.reply("test concatin trigger", "Helloworld!")
+        self.reply("test concat in trigger with space and optional", "Hello world!")

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -48,6 +48,12 @@ class ParserOptionTest(RiveScriptTestCase):
             - Hello
             ^ \sworld!
 
+            ! local concat = space
+            + test concat space
+            ^ in trigger
+            - Hello
+            ^ world!
+
             // the option is file scoped so it can be left at
             // any setting and won't affect subsequent parses
             ! local concat = newline
@@ -67,3 +73,4 @@ class ParserOptionTest(RiveScriptTestCase):
         self.reply("test concat second file", "Helloworld!")
         self.reply("test concatin trigger", "Helloworld!")
         self.reply("test concat in trigger with space and optional", "Hello world!")
+        self.reply("test concat space in trigger", "Hello world!")


### PR DESCRIPTION
- No change in order of check_syntax (still before parsing continue ^) because space is only checked in lookahead (not yet checked for syntax at the time of looking ahead) 

- Adding unit tests that allow continue in triggers 