### PR TITLE
Check syntax

### DIFF
--- a/rivescript/parser.py
+++ b/rivescript/parser.py
@@ -574,6 +574,14 @@ class Parser(object):
                     angle += 1
                 elif char == '>':
                     angle -= 1
+                elif char == '|':
+                    if parens == 0 and square == 0:   # Pipe outside the alternative and option
+                        return "Pipe | must be within parenthesis brackets or square brackets"
+
+                sum = parens + square + curly + angle   # At each character, not more than 1 bracket opens
+                for special_char_count in [parens, square, curly, angle, sum]:
+                    if special_char_count not in (0, 1):
+                        return "Unbalanced brackets"
 
             # Any mismatches?
             if parens != 0:

--- a/rivescript/parser.py
+++ b/rivescript/parser.py
@@ -578,7 +578,10 @@ class Parser(object):
                     if parens == 0 and square == 0:   # Pipe outside the alternative and option
                         return "Pipe | must be within parenthesis brackets or square brackets"
 
-                total = parens + square + curly + angle   # At each character, not more than 1 bracket opens
+                if (angle != 0) and (char in {"(", ")", "[", "]", "{", "}"}):
+                    return "Angle bracket must be closed before closing or opening other type of brackets"
+
+                total = parens + square + curly   # At each character, not more than 1 bracket opens, except <>
                 for special_char_count in [parens, square, curly, angle, total]:
                     if special_char_count not in (0, 1):
                         return "Unbalanced brackets"

--- a/rivescript/parser.py
+++ b/rivescript/parser.py
@@ -578,8 +578,8 @@ class Parser(object):
                     if parens == 0 and square == 0:   # Pipe outside the alternative and option
                         return "Pipe | must be within parenthesis brackets or square brackets"
 
-                sum = parens + square + curly + angle   # At each character, not more than 1 bracket opens
-                for special_char_count in [parens, square, curly, angle, sum]:
+                total = parens + square + curly + angle   # At each character, not more than 1 bracket opens
+                for special_char_count in [parens, square, curly, angle, total]:
                     if special_char_count not in (0, 1):
                         return "Unbalanced brackets"
 

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -33,8 +33,10 @@ class MessageFormatTests(RiveScriptTestCase):
     def test_check_syntax(self):
         mismatch_brackets = ["a (b", "a [b", "a {b", "a <b", "a b)", "a b]", "a b}", "a b>"]
         empty_pipes = ["[a|b| ]", "[a|b|]", "[a| |c]", "[a||c]", "[ |b|c]", "[|b|c]"]
+        advanced_brackets = [") a (", "] b [", "> c <", "} d {", "a (b [c) d]", "a (b <c) d>", "a (b [c|d] e)"]
+        pipe_outside_brackets = ["a|b", "a|", "|b", "(a|b) | (c|d)", "(a|b)|(c|d)"]
 
-        for failing_trigger in mismatch_brackets+empty_pipes:
+        for failing_trigger in mismatch_brackets + empty_pipes + advanced_brackets + pipe_outside_brackets:
             self.assertRaises(Exception, self.new, """
                 + {}
                 - hi

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -33,14 +33,28 @@ class MessageFormatTests(RiveScriptTestCase):
     def test_check_syntax(self):
         mismatch_brackets = ["a (b", "a [b", "a {b", "a <b", "a b)", "a b]", "a b}", "a b>"]
         empty_pipes = ["[a|b| ]", "[a|b|]", "[a| |c]", "[a||c]", "[ |b|c]", "[|b|c]"]
-        advanced_brackets = [") a (", "] b [", "> c <", "} d {", "a (b [c) d]", "a (b <c) d>", "a (b [c|d] e)"]
-        pipe_outside_brackets = ["a|b", "a|", "|b", "(a|b) | (c|d)", "(a|b)|(c|d)"]
+        advanced_brackets = [") a (", "] b [", "> c <", "} d {", "a (b [c) d]", "a (b [c|d] e)"]
+        angle_brackets = ["(a <b) c>", "<a (b > c)", "[a <b ] c>", "< a [b > c]", "{ a < b } c >", "< a {b > c }"]
+        pipe_outside = ["a|b", "a|", "|b", "(a|b) | (c|d)", "(a|b)|(c|d)"]
 
-        for failing_trigger in mismatch_brackets + empty_pipes + advanced_brackets + pipe_outside_brackets:
+        for failing_trigger in mismatch_brackets + empty_pipes + advanced_brackets + pipe_outside + angle_brackets:
             self.assertRaises(Exception, self.new, """
                 + {}
                 - hi
             """.format(failing_trigger))
+
+        self.new("""
+            ! version = 2.0
+
+            // Bot variables
+            ! var name = Tutorial
+            ! var nickname = tut
+
+            + [<bot name>|<nickname>] *
+            - You called?
+        """)
+        self.reply("Tutorial", "You called?")
+        self.reply("tut", "You called?")
 
     def test_invalid_character_raise_exception(self):
         self.assertRaises(Exception, self.new, """


### PR DESCRIPTION
Provide stricter check for syntax that slipped through earlier check. Following up from the [comment](https://github.com/aichaos/rivescript-python/issues/86#issuecomment-282408186) in  #86. 