### PR TITLE
Docker to build Linux packages

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,7 +4,6 @@ recursive-include docs *.*
 include Changes.md
 include README.md
 include LICENSE
-recursive-include brain *.rive
 recursive-include eg *.*
 recursive-include tests *.py
 include example.py

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,28 @@
+.PHONY: all
 all: build
 
+.PHONY: build
 build:
 	python setup.py build
 
+.PHONY: install
 install:
 	python setup.py install
 
+.PHONY: test
 test:
 	pip install -r requirements.txt
 	nosetests
 
+.PHONY: clean
 clean:
 	rm -rf build dist rivescript.egg-info
 	find . -name '*.pyc' -delete
 
-.PHONY: build install test clean
+.PHONY: rpm
+rpm:
+	./docker/build.sh
+
+.PHONY: docker.rpm
+docker.rpm:
+	./docker/package.sh

--- a/docker/Fedora.dockerfile
+++ b/docker/Fedora.dockerfile
@@ -1,0 +1,40 @@
+# RPM build script for Fedora (latest)
+#
+# Usage:
+#   (From the rivescript-python git root)
+#   sudo docker build -t rivescript_fedora -f ./docker/Fedora.dockerfile .
+#   sudo docker run rivescript_fedora -v ./docker/dist:/mnt/export
+#
+# Bind mount: /mnt/export in the image is where the final rpm files are copied
+# to, so mount it on the host to get at these files.
+
+FROM fedora:latest
+MAINTAINER Noah Petherbridge <root@kirsle.net>
+ENV RIVESCRIPT_DOCKER_BUILD 42
+
+# Updates and requirements
+RUN dnf -y update && dnf -y install rpm-build sudo make \
+    perl python3-devel python2-devel && \
+    dnf clean all
+
+# Create a user to build the packages.
+RUN useradd builder -u 1000 -m -G users,wheel && \
+    echo "builder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
+    echo "# macros"                      >  /home/builder/.rpmmacros && \
+    echo "%_topdir    /home/builder/rpm" >> /home/builder/.rpmmacros && \
+    echo "%_sourcedir %{_topdir}"        >> /home/builder/.rpmmacros && \
+    echo "%_builddir  %{_topdir}"        >> /home/builder/.rpmmacros && \
+    echo "%_specdir   %{_topdir}"        >> /home/builder/.rpmmacros && \
+    echo "%_rpmdir    %{_topdir}"        >> /home/builder/.rpmmacros && \
+    echo "%_srcrpmdir %{_topdir}"        >> /home/builder/.rpmmacros && \
+    mkdir /home/builder/rpm && \
+    chown -R builder /home/builder
+
+# Add the Python tree to /build in the container.
+WORKDIR /home/builder/src
+ADD . /home/builder/src
+RUN chown -R builder /home/builder
+
+USER builder
+RUN pip install --user --trusted-host pypi.python.org -r requirements.txt
+CMD ["make", "docker.rpm"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,12 @@
+# Docker Scripts
+
+This folder contains Docker scripts to build packages for various Linux
+distros. Currently it can output packages for Fedora latest.
+
+To use, run the Make command from the top-level folder of this git repo:
+
+```bash
+make rpm
+```
+
+Final output RPMs will be placed in `docker/dist/`

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [[ ! -f "./python-rivescript.spec" ]]; then
+    cd ..
+    if [[ ! -f "./python-rivescript.spec" ]]; then
+        echo Could not find the python-rivescript.spec; are you in the right folder?
+        exit 1
+    fi
+fi
+
+mkdir -p ./docker/dist
+
+sudo docker build -t rivescript_fedora -f ./docker/Fedora.dockerfile .
+sudo docker run --rm -v "$(pwd)/docker/dist:/mnt/export:z" rivescript_fedora

--- a/docker/package.sh
+++ b/docker/package.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+if [[ "x$RIVESCRIPT_DOCKER_BUILD" == "x" ]]; then
+    echo This script should only be run from the Docker environment.
+    exit 1
+fi
+
+if [[ ! -f "./python-rivescript.spec" ]]; then
+    cd ..
+    if [[ ! -f "./python-rivescript.spec" ]]; then
+        echo Could not find the python-rivescript.spec; are you in the right folder?
+        exit 1
+    fi
+fi
+
+# RiveScript module version
+VERSION=$(grep -e '__version__' rivescript/__init__.py | head -n 1 | cut -d "'" -f 2)
+
+# Make sure the rpm spec always has this version too.
+perl -pi -e "s/^%global version .+?$/%global version ${VERSION}/g" python-rivescript.spec
+
+# Build the tarball and copy everything into the rpmbuild root.
+python setup.py sdist
+cp dist/*.tar.gz ${HOME}/rpm/
+cp python-rivescript.spec ${HOME}/rpm/
+echo $(ls -hal dist)
+cd ${HOME}/rpm
+echo $(ls -hal)
+
+rpmbuild -bb python-rivescript.spec
+echo $(ls -hal)
+sudo find . -name '*.rpm' -exec cp {} /mnt/export \;
+sudo chown 1000:1000 /mnt/export/*.rpm

--- a/python-rivescript.spec
+++ b/python-rivescript.spec
@@ -1,9 +1,10 @@
 %global srcname rivescript
 %global sum A Chatterbot Scripting Language
 %global desc A scripting language to make it easy to write responses for a chatterbot.
+%global version 1.14.9
 
 Name:           python-%{srcname}
-Version:        1.14.9
+Version:        %{version}
 Release:        1%{?dist}
 Summary:        %{sum}
 


### PR DESCRIPTION
Adds a `make rpm` command that will use Docker to create RPM packages for Fedora.

This branch is an experiment to run a "poor man's CI" and build packages without needing a full Jenkins setup or anything. Eventually want to add Ubuntu and/or Debian images too.

1. `make rpm` runs `docker/build.sh` which runs the Docker build/run commands.
2. `make docker.rpm` runs `docker/package.sh` from inside the Docker container to actually run the rpmbuild steps and export them to a bind mount on the host. It safely does nothing if you run it outside the Docker environment.